### PR TITLE
chore: upgrade Spring boot to 3.5.3

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 plugins {
 	id 'java'
-	id 'org.springframework.boot' version '3.3.0'
+	id 'org.springframework.boot' version '3.5.3'
 	id 'io.spring.dependency-management' version '1.1.5'
 }
 

--- a/src/test/java/com/company/officecommute/domain/employee/EmployeeTest.java
+++ b/src/test/java/com/company/officecommute/domain/employee/EmployeeTest.java
@@ -31,7 +31,7 @@ class EmployeeTest {
                         .withRole(null)
                         .build())
                 .isInstanceOf(IllegalArgumentException.class)
-                .hasMessage(String.format("employee의 role이 올바르지 않은 형식(%s)입니다. 다시 입력해주세요.", null));
+                .hasMessage(String.format("employee의 role이 올바르지 않은 형식(%s)입니다. 다시 입력해주세요.", (Object) null));
     }
 
     @Test
@@ -43,7 +43,7 @@ class EmployeeTest {
                         .withBirthday(null)
                         .build())
                 .isInstanceOf(IllegalArgumentException.class)
-                .hasMessage(String.format("employee의 birthday이 올바르지 않은 형식(%s)입니다. 다시 입력해주세요.", null));
+                .hasMessage(String.format("employee의 birthday이 올바르지 않은 형식(%s)입니다. 다시 입력해주세요.", (Object) null));
     }
 
     @Test
@@ -56,7 +56,7 @@ class EmployeeTest {
                         .withStartDate(null)
                         .build())
                 .isInstanceOf(IllegalArgumentException.class)
-                .hasMessage(String.format("employee의 workStartDate이 올바르지 않은 형식(%s)입니다. 다시 입력해주세요.", null));
+                .hasMessage(String.format("employee의 workStartDate이 올바르지 않은 형식(%s)입니다. 다시 입력해주세요.", (Object) null));
 
     }
 

--- a/src/test/java/com/company/officecommute/web/ApiConvertor1Test.java
+++ b/src/test/java/com/company/officecommute/web/ApiConvertor1Test.java
@@ -5,6 +5,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.web.client.RestTemplate;
 
 import java.net.URI;
@@ -19,10 +20,10 @@ import static org.mockito.Mockito.when;
 @WebMvcTest(ApiConvertor.class)
 class ApiConvertor1Test {
 
-    @MockBean
+    @MockitoBean
     private RestTemplate restTemplate;
 
-    @MockBean
+    @MockitoBean
     private ApiProperties apiProperties;
 
     @Autowired


### PR DESCRIPTION
- upgrade Spring boot 3.30 to 3.5.3
- error fix in `EmployeeTest.java`
    - `String.format()` call with null argument caused ambiguity between varargs and non-varargs invocation
    - Solution: Explicitly cast null to (Object) to clarify intent
- `@MockBean` is deprecated. So, change to `@MockitoBean`