### PR TITLE
feat: Add Employee-Team relationship and optimize queries with fetch join

### DIFF
--- a/src/main/java/com/company/officecommute/domain/employee/Employee.java
+++ b/src/main/java/com/company/officecommute/domain/employee/Employee.java
@@ -2,13 +2,17 @@ package com.company.officecommute.domain.employee;
 
 import com.company.officecommute.domain.annual_leave.AnnualLeave;
 import com.company.officecommute.domain.annual_leave.AnnualLeaves;
+import com.company.officecommute.domain.team.Team;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
 
 import java.time.LocalDate;
 import java.util.List;
@@ -20,6 +24,10 @@ public class Employee {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long employeeId;
+
+    @ManyToOne(fetch = FetchType.LAZY) // 왜? LAZY?
+    @JoinColumn(name= "team_id")
+    private Team team;
 
     private String name;
 
@@ -47,7 +55,7 @@ public class Employee {
             LocalDate birthday,
             LocalDate workStartDate
     ) {
-        this(null, name, null, role, birthday, workStartDate, null, null);
+        this(null, null, name, null, role, birthday, workStartDate, null, null);
     }
 
     public Employee(
@@ -58,7 +66,7 @@ public class Employee {
             LocalDate birthday,
             LocalDate workStartDate
     ) {
-        this(employeeId, name, teamName, role, birthday, workStartDate, null, null);
+        this(employeeId, null, name, teamName, role, birthday, workStartDate, null, null);
     }
 
     public Employee(
@@ -69,11 +77,12 @@ public class Employee {
             String employeeCode,
             String password
     ) {
-        this(null, name, null, role, birthday, workStartDate, employeeCode, password);
+        this(null, null, name, null, role, birthday, workStartDate, employeeCode, password);
     }
 
     public Employee(
             Long employeeId,
+            Team team,
             String name,
             String teamName,
             Role role,
@@ -83,6 +92,7 @@ public class Employee {
             String password
     ) {
         this.employeeId = employeeId;
+        this.team = team;
         this.name = validateName(name);
         this.teamName = teamName;
         this.role = Objects.requireNonNull(role, "role은 null일 수 없습니다");
@@ -118,6 +128,10 @@ public class Employee {
 
     public Long getEmployeeId() {
         return employeeId;
+    }
+
+    public Team getTeam() {
+        return team;
     }
 
     public String getName() {

--- a/src/main/java/com/company/officecommute/domain/team/Team.java
+++ b/src/main/java/com/company/officecommute/domain/team/Team.java
@@ -70,6 +70,12 @@ public class Team {
         this.memberCount++;
     }
 
+    public void decreaseMemberCount() {
+        if (memberCount > 0) {
+            this.memberCount--;
+        }
+    }
+
     public boolean isNotEnoughCriteria(List<AnnualLeave> wantedLeaves) {
         return isNotEnoughCriteria(new AnnualLeaves(wantedLeaves));
     }

--- a/src/main/java/com/company/officecommute/repository/employee/EmployeeRepository.java
+++ b/src/main/java/com/company/officecommute/repository/employee/EmployeeRepository.java
@@ -3,6 +3,7 @@ package com.company.officecommute.repository.employee;
 import com.company.officecommute.domain.employee.Employee;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 import java.util.Optional;
@@ -21,8 +22,8 @@ public interface EmployeeRepository extends JpaRepository<Employee, Long> {
     @Query("""
             SELECT e
             FROM Employee e
-            JOIN FETCH e.team
+            LEFT JOIN FETCH e.team
             WHERE e.employeeId = :employeeId
             """)
-    Optional<Employee> findByIdWithTeam(Long employeeId);
+    Optional<Employee> findByEmployeeIdWithTeam(@Param("employeeId") Long employeeId);
 }

--- a/src/main/java/com/company/officecommute/repository/employee/EmployeeRepository.java
+++ b/src/main/java/com/company/officecommute/repository/employee/EmployeeRepository.java
@@ -17,4 +17,12 @@ public interface EmployeeRepository extends JpaRepository<Employee, Long> {
     Optional<Employee> findByEmployeeCode(String employeeCode);
 
     boolean existsByEmployeeCode(String employeeCode);
+
+    @Query("""
+            SELECT e
+            FROM Employee e
+            JOIN FETCH e.team
+            WHERE e.employeeId = :employeeId
+            """)
+    Optional<Employee> findByIdWithTeam(Long employeeId);
 }

--- a/src/main/java/com/company/officecommute/service/employee/EmployeeService.java
+++ b/src/main/java/com/company/officecommute/service/employee/EmployeeService.java
@@ -102,11 +102,10 @@ public class EmployeeService {
                 .toList();
 
         // TODO: 세 개의 쿼리를 한 번에 처리할 수 있도록 개선
-        // Query 1: SELECT * FROM employee WHERE employee_id = ?
-        Employee employee = employeeDomainService.findEmployeeById(employeeId);
-        // Query 2: SELECT * FROM team WHERE name = ?
-        // ❌ employee.getTeamName()으로 얻은 문자열로 또 조회!
-        Team team = teamDomainService.findTeamByName(employee.getTeamName());
+        Employee employee = employeeRepository.findByIdWithTeam(employeeId)
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 직원입니다."));
+        Team team = employee.getTeam();
+
         // Query 3: SELECT * FROM annual_leave WHERE employee_id = ?
         List<AnnualLeave> existingAnnualLeaves = annualLeaveRepository.findByEmployeeId(employeeId);
 

--- a/src/test/java/com/company/officecommute/domain/employee/EmployeeTest.java
+++ b/src/test/java/com/company/officecommute/domain/employee/EmployeeTest.java
@@ -1,14 +1,15 @@
 package com.company.officecommute.domain.employee;
 
+import com.company.officecommute.domain.team.Team;
 import com.company.officecommute.service.employee.EmployeeBuilder;
-import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.NullAndEmptySource;
 
 import java.time.LocalDate;
 
-import static org.assertj.core.api.Assertions.*;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 class EmployeeTest {
 
@@ -35,7 +36,7 @@ class EmployeeTest {
                 .withPassword("password123!")
                 .build();
 
-        employee.changeTeam("A");
+        employee.changeTeam(new Team("A"));
         assertThat(employee.getTeamName()).isEqualTo("A");
     }
 }

--- a/src/test/java/com/company/officecommute/service/employee/EmployeeBuilder.java
+++ b/src/test/java/com/company/officecommute/service/employee/EmployeeBuilder.java
@@ -2,11 +2,13 @@ package com.company.officecommute.service.employee;
 
 import com.company.officecommute.domain.employee.Employee;
 import com.company.officecommute.domain.employee.Role;
+import com.company.officecommute.domain.team.Team;
 
 import java.time.LocalDate;
 
 public class EmployeeBuilder {
     private Long id;
+    private Team team;
     private String name;
     private String teamName;
     private Role role;
@@ -17,6 +19,11 @@ public class EmployeeBuilder {
 
     public EmployeeBuilder withId(Long id) {
         this.id = id;
+        return this;
+    }
+
+    public EmployeeBuilder withTeam(Team team) {
+        this.team = team;
         return this;
     }
 
@@ -56,6 +63,6 @@ public class EmployeeBuilder {
     }
 
     public Employee build() {
-        return new Employee(id, name, teamName, role, birthday, workStartDate, employeeCode, password);
+        return new Employee(id, team, name, teamName, role, birthday, workStartDate, employeeCode, password);
     }
 }

--- a/src/test/java/com/company/officecommute/service/employee/EmployeeServiceTest.java
+++ b/src/test/java/com/company/officecommute/service/employee/EmployeeServiceTest.java
@@ -60,8 +60,10 @@ class EmployeeServiceTest {
     @BeforeEach
     void setUp() {
         employeeId = 1L;
+        team = new Team("백엔드팀");
         employee = new EmployeeBuilder()
                 .withId(employeeId)
+                .withTeam(team)
                 .withName("임형준")
                 .withRole(MEMBER)
                 .withBirthday(LocalDate.of(1998, 8, 18))
@@ -71,7 +73,6 @@ class EmployeeServiceTest {
                 .withTeamName("백엔드팀")
                 .build();
 
-        team = new Team("백엔드팀");
     }
 
     @Test
@@ -212,10 +213,12 @@ class EmployeeServiceTest {
                 LocalDate.now().plusDays(10),
                 LocalDate.now().plusDays(11)
         );
-        BDDMockito.given(employeeDomainService.findEmployeeById(1L))
-                .willReturn(employee);
-        BDDMockito.given(teamDomainService.findTeamByName("백엔드팀"))
-                .willReturn(team);
+        // BDDMockito.given(employeeDomainService.findEmployeeById(1L))
+        //         .willReturn(employee);
+        // BDDMockito.given(teamDomainService.findTeamByName("백엔드팀"))
+        //         .willReturn(team);
+        BDDMockito.given(employeeRepository.findByIdWithTeam(1L))
+                .willReturn(Optional.of(employee));
         BDDMockito.given(annualLeaveRepository.findByEmployeeId(employeeId))
                 .willReturn(List.of());
 

--- a/src/test/java/com/company/officecommute/service/employee/EmployeeServiceTest.java
+++ b/src/test/java/com/company/officecommute/service/employee/EmployeeServiceTest.java
@@ -216,21 +216,25 @@ class EmployeeServiceTest {
                 .willReturn(Optional.of(employee));
         BDDMockito.given(annualLeaveRepository.findByEmployeeId(employeeId))
                 .willReturn(List.of());
+
         List<AnnualLeave> savedLeaves = List.of(
                 new AnnualLeave(1L, employeeId, wantedDates.get(0)),
                 new AnnualLeave(2L, employeeId, wantedDates.get(1))
         );
         BDDMockito.given(annualLeaveRepository.saveAll(any()))
                 .willReturn(savedLeaves);
-        BDDMockito.given(commuteHistoryRepository.save(any(CommuteHistory.class)))
-                .willReturn(new CommuteHistory(employeeId));
+        BDDMockito.given(commuteHistoryRepository.saveAll(any()))
+                .willReturn(List.of(
+                        new CommuteHistory(employeeId),
+                        new CommuteHistory(employeeId)
+                ));
 
         List<AnnualLeaveEnrollmentResponse> responses = employeeService.enrollAnnualLeave(employeeId, wantedDates);
 
         assertThat(responses).hasSize(2);
         assertThat(responses.get(0).annualLeaveId()).isEqualTo(1L);
         assertThat(responses.get(0).enrolledDate()).isEqualTo(wantedDates.get(0));
-        verify(commuteHistoryRepository, times(2)).save(any(CommuteHistory.class));
+        verify(commuteHistoryRepository, times(1)).saveAll(any());
     }
 
     @Test

--- a/src/test/java/com/company/officecommute/service/employee/EmployeeServiceTest.java
+++ b/src/test/java/com/company/officecommute/service/employee/EmployeeServiceTest.java
@@ -70,7 +70,6 @@ class EmployeeServiceTest {
                 .withStartDate(LocalDate.of(2024, 1, 1))
                 .withEmployeeCode("EMP001")
                 .withPassword("password123!")
-                .withTeamName("백엔드팀")
                 .build();
 
     }
@@ -213,15 +212,10 @@ class EmployeeServiceTest {
                 LocalDate.now().plusDays(10),
                 LocalDate.now().plusDays(11)
         );
-        // BDDMockito.given(employeeDomainService.findEmployeeById(1L))
-        //         .willReturn(employee);
-        // BDDMockito.given(teamDomainService.findTeamByName("백엔드팀"))
-        //         .willReturn(team);
-        BDDMockito.given(employeeRepository.findByIdWithTeam(1L))
+        BDDMockito.given(employeeRepository.findByEmployeeIdWithTeam(1L))
                 .willReturn(Optional.of(employee));
         BDDMockito.given(annualLeaveRepository.findByEmployeeId(employeeId))
                 .willReturn(List.of());
-
         List<AnnualLeave> savedLeaves = List.of(
                 new AnnualLeave(1L, employeeId, wantedDates.get(0)),
                 new AnnualLeave(2L, employeeId, wantedDates.get(1))


### PR DESCRIPTION
## Changes
- Add JPA relationship between Employee and Team (`@ManyToOne`)
- Optimize queries using fetch join (2 queries → 1 query)
- Move business logic to domain entities
- Improve code readability

## Technical Improvements

Before:
```java
Employee employee = findById(employeeId);           // 1st query
Team team = findByName(employee.getTeamName());     // 2nd query

// Individual saves
savedLeaves.stream()
    .map(annualLeave -> new CommuteHistory(employeeId))
    .forEach(commuteHistoryRepository::save);       // Multiple save calls
```
After:
```java
Employee employee = findByEmployeeIdWithTeam(employeeId);  // 1 join query

// saveAll
List<CommuteHistory> commuteHistories = savedLeaves.stream()
    .map(annualLeave -> new CommuteHistory(employeeId))
    .toList();
commuteHistoryRepository.saveAll(commuteHistories);        // Single saveAll call
```