### PR TITLE
연차의 day-off 기록 생성을 출퇴근 서비스로 위임

### DIFF
--- a/src/main/java/com/company/officecommute/service/annual_leave/AnnualLeaveService.java
+++ b/src/main/java/com/company/officecommute/service/annual_leave/AnnualLeaveService.java
@@ -1,15 +1,13 @@
 package com.company.officecommute.service.annual_leave;
 
 import com.company.officecommute.domain.annual_leave.AnnualLeave;
-import com.company.officecommute.domain.annual_leave.AnnualLeaves;
-import com.company.officecommute.domain.commute.CommuteHistory;
 import com.company.officecommute.domain.employee.Employee;
 import com.company.officecommute.domain.employee.EmployeeNotFoundException;
 import com.company.officecommute.dto.annual_leave.response.AnnualLeaveEnrollmentResponse;
 import com.company.officecommute.dto.annual_leave.response.AnnualLeaveGetRemainingResponse;
 import com.company.officecommute.repository.annual_leave.AnnualLeaveRepository;
-import com.company.officecommute.repository.commute.CommuteHistoryRepository;
 import com.company.officecommute.repository.employee.EmployeeRepository;
+import com.company.officecommute.service.commute.CommuteHistoryService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
@@ -25,15 +23,15 @@ public class AnnualLeaveService {
 
     private final EmployeeRepository employeeRepository;
     private final AnnualLeaveRepository annualLeaveRepository;
-    private final CommuteHistoryRepository commuteHistoryRepository;
+    private final CommuteHistoryService commuteHistoryService;
 
     public AnnualLeaveService(
             EmployeeRepository employeeRepository,
             AnnualLeaveRepository annualLeaveRepository,
-            CommuteHistoryRepository commuteHistoryRepository) {
+            CommuteHistoryService commuteHistoryService) {
         this.employeeRepository = employeeRepository;
         this.annualLeaveRepository = annualLeaveRepository;
-        this.commuteHistoryRepository = commuteHistoryRepository;
+        this.commuteHistoryService = commuteHistoryService;
     }
 
     @Transactional
@@ -43,13 +41,9 @@ public class AnnualLeaveService {
                 .orElseThrow(() -> new EmployeeNotFoundException(employeeId));
         List<AnnualLeave> existingAnnualLeaves = annualLeaveRepository.findByEmployeeId(employeeId);
         List<AnnualLeave> enrolledLeaves = employee.enrollAnnualLeave(wantedDates, existingAnnualLeaves);
-
         List<AnnualLeave> savedLeaves = annualLeaveRepository.saveAll(enrolledLeaves);
 
-        List<CommuteHistory> commuteHistories = savedLeaves.stream()
-                .map(annualLeave -> new CommuteHistory(employeeId, annualLeave.getWantedDate(), employee.getZoneId()))
-                .toList();
-        commuteHistoryRepository.saveAll(commuteHistories);
+        commuteHistoryService.registerDayOffs(employeeId, savedLeaves, employee.getZoneId());
 
         log.info("연차 신청 완료 - employeeId: {}, 신청한 연차 수: {}", employeeId, savedLeaves.size());
         return AnnualLeaveEnrollmentResponse.listFrom(savedLeaves);

--- a/src/main/java/com/company/officecommute/service/commute/CommuteHistoryService.java
+++ b/src/main/java/com/company/officecommute/service/commute/CommuteHistoryService.java
@@ -1,5 +1,6 @@
 package com.company.officecommute.service.commute;
 
+import com.company.officecommute.domain.annual_leave.AnnualLeave;
 import com.company.officecommute.domain.commute.CommuteHistory;
 import com.company.officecommute.domain.commute.CommuteNotStartedException;
 import com.company.officecommute.domain.commute.DuplicateWorkOnDateException;
@@ -91,6 +92,13 @@ public class CommuteHistoryService {
         List<CommuteHistory> histories = findCommuteHistoriesByEmployeeIdAndMonth(
                 employee.getEmployeeId(), yearMonth);
         return new CommuteHistories(histories).toWorkDurationPerDateResponse();
+    }
+
+    public void registerDayOffs(Long employeeId, List<AnnualLeave> savedLeaves, ZoneId zoneId) {
+        List<CommuteHistory> commuteHistories = savedLeaves.stream()
+                .map(annualLeave -> new CommuteHistory(employeeId, annualLeave.getWantedDate(), zoneId))
+                .toList();
+        commuteHistoryRepository.saveAll(commuteHistories);
     }
 
     private Employee getEmployee(Long employeeId) {

--- a/src/test/java/com/company/officecommute/service/annual_leave/AnnualLeaveServiceTest.java
+++ b/src/test/java/com/company/officecommute/service/annual_leave/AnnualLeaveServiceTest.java
@@ -1,14 +1,13 @@
 package com.company.officecommute.service.annual_leave;
 
 import com.company.officecommute.domain.annual_leave.AnnualLeave;
-import com.company.officecommute.domain.commute.CommuteHistory;
 import com.company.officecommute.domain.employee.Employee;
 import com.company.officecommute.domain.team.Team;
 import com.company.officecommute.dto.annual_leave.response.AnnualLeaveEnrollmentResponse;
 import com.company.officecommute.dto.annual_leave.response.AnnualLeaveGetRemainingResponse;
 import com.company.officecommute.repository.annual_leave.AnnualLeaveRepository;
-import com.company.officecommute.repository.commute.CommuteHistoryRepository;
 import com.company.officecommute.repository.employee.EmployeeRepository;
+import com.company.officecommute.service.commute.CommuteHistoryService;
 import com.company.officecommute.service.employee.EmployeeBuilder;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -26,6 +25,7 @@ import java.util.Optional;
 import static com.company.officecommute.domain.employee.Role.MEMBER;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
@@ -39,7 +39,7 @@ class AnnualLeaveServiceTest {
     @Mock
     private AnnualLeaveRepository annualLeaveRepository;
     @Mock
-    private CommuteHistoryRepository commuteHistoryRepository;
+    private CommuteHistoryService commuteHistoryService;
 
     private Long employeeId;
     private Employee employee;
@@ -79,18 +79,14 @@ class AnnualLeaveServiceTest {
         );
         BDDMockito.given(annualLeaveRepository.saveAll(any()))
                 .willReturn(savedLeaves);
-        BDDMockito.given(commuteHistoryRepository.saveAll(any()))
-                .willReturn(List.of(
-                        new CommuteHistory(employeeId, wantedDates.get(0)),
-                        new CommuteHistory(employeeId, wantedDates.get(1))
-                ));
 
         List<AnnualLeaveEnrollmentResponse> responses = annualLeaveService.enrollAnnualLeave(employeeId, wantedDates);
 
         assertThat(responses).hasSize(2);
         assertThat(responses.get(0).annualLeaveId()).isEqualTo(1L);
         assertThat(responses.get(0).enrolledDate()).isEqualTo(wantedDates.get(0));
-        verify(commuteHistoryRepository, times(1)).saveAll(any());
+        verify(commuteHistoryService, times(1))
+                .registerDayOffs(eq(employeeId), eq(savedLeaves), eq(employee.getZoneId()));
     }
 
     @Test


### PR DESCRIPTION
연차 서비스(AnnualLeaveService)가 CommuteHistory를 직접 생성, 저장하던 것을 commuteHistoryService.registerDayOffs() 호출로 변경. 변경의 이유가 출퇴근 도메인에 있는데 변경의 영향이 연차 도메인까지 세어 나가던 결함을 끊기 위함. 출퇴근 기록 방식이 바뀌어도 이제 연차 서비스는 영향을 받지 않는다. 거리를 줄이는 작업이며, 그림자 기록 생성(연차를 일한 시간 0분으로 하는 데이터로 생성) 제거는 후속 작업