### PR TITLE
Implement monthly overtime report auto-dispatch with batch scheduler and email

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -19,6 +19,27 @@ PUBLIC_API_READ_TIMEOUT=5s
 # 서버 포트 (선택사항)
 SERVER_PORT=8080
 
+# ----------------------------------------------------------------------
+# 매월 초과근무 리포트 메일 발송 (ADR 3)
+#   prod 프로파일은 아래 값에 기본값이 없다 — 미설정 시 부팅이 실패한다.
+#   매월 1일에야 "메일이 안 온다"를 발견하는 것보다 부팅 실패가 싸다.
+#   dev/mysql 은 spring.mail.host 기본값(localhost)으로 뜨며 실제 발송 경로가 없다.
+# ----------------------------------------------------------------------
+MAIL_HOST=
+MAIL_PORT=587
+MAIL_USERNAME=
+MAIL_PASSWORD=
+# SMTP 인증/STARTTLS 사용 여부 (선택, prod 기본값 true)
+MAIL_SMTP_AUTH=true
+MAIL_SMTP_STARTTLS=true
+
+# 발신 주소
+REPORT_MAIL_FROM=
+# 대표 — 정상 리포트의 유일한 수신자
+REPORT_MAIL_CEO=
+# 근태 관리자 — 미마감 보류·발송 실패 알림 수신자. 복수는 쉼표 구분(a@x.com,b@x.com)
+REPORT_MAIL_MANAGERS=
+
 # 시드 admin 비밀번호 로테이션용 BCrypt 해시 (V11, 운영 필수 — 미설정 시 prod 부팅 실패)
 # dev/mysql 프로파일에서는 없어도 된다 (dev 는 Flyway 미사용, mysql 은 dev 해시 기본값)
 ADMIN_PASSWORD_HASH=

--- a/.env.example
+++ b/.env.example
@@ -12,6 +12,9 @@ DB_PASSWORD=office_password
 # 공공 API 설정 (실제 API 테스트시 필요)
 PUBLIC_API_SERVICE_KEY=your-actual-api-service-key-here
 PUBLIC_API_URL=https://apis.data.go.kr/B090041/openapi/service/SpcdeInfoService/getRestDeInfo
+# 외부 API 타임아웃 (선택, 기본 3s/5s — 재배포 없이 조정하려면 여기서 덮어쓴다)
+PUBLIC_API_CONNECT_TIMEOUT=3s
+PUBLIC_API_READ_TIMEOUT=5s
 
 # 서버 포트 (선택사항)
 SERVER_PORT=8080

--- a/TODO.md
+++ b/TODO.md
@@ -113,29 +113,37 @@
 잘못된 급여 자료가 대표에게 도착하는 것이 메일이 하루 늦는 것보다 비싸다.
 문제가 있으면 대표 메일 대신 근태 관리자에게 경고를 보낸다.
 
-**전제: 배치도 메일 발송도 아직 없다.** 스케줄러(`@Scheduled`)와 메일 의존성이
-프로젝트에 존재하지 않으므로, 이 절의 항목들은 기존 코드의 수정이 아니라
-발송 경로를 새로 만드는 작업이다. 리포트 생성부(`OverTimeReportService`)는 준비돼 있다.
+**구현 완료 (2026-08-11, ADR 3 Step 1~7).** 스케줄러도 메일도 프로젝트에 없었으므로
+이 절은 기존 코드 수정이 아니라 발송 경로 신설이었다. 설계 근거와 감수 사항은
+`src/test/docs/adr/2026_08_10_adr3.md` 참조.
 
-- [ ] 스케줄러 도입(프로젝트 첫 도입): `@EnableScheduling` + `@Scheduled`에
-      cron `zone = "Asia/Seoul"` 명시. "전월"은 주입된 `Clock`에서 파생 —
-      `LocalDate.now()` 직접 호출 금지
-- [ ] 배치는 `StreamingResponseBody` 컨트롤러를 타지 말고 서비스 계층을 직접 호출한다.
-      실패 시 부분 파일이 나가지 않도록 임시 파일에 다 쓴 뒤 첨부한다
-- [ ] **발송 이력 테이블 `UNIQUE(year_month)`** — 중복 발송 방지의 핵심.
-      배치 재시도와 수동 재실행이 겹쳐도 대표는 한 달에 한 번만 받는다
-- [ ] **재시도가 원장을 대체한다**: 1일 오전 시도가 실패하면(공휴일 API 다운 포함)
-      몇 시간 간격으로 1~3일 재시도. 발송 이력 유니크 덕에 성공 시 자동 중단, 멱등.
-      공휴일 프리플라이트는 별도 항목이 아니다 — 라이브 호출이 fail-closed라
-      데이터 문제가 곧 배치 실패로 드러나고, 재시도 대상이 된다
-- [ ] **조용한 실패 차단** — 재시도까지 소진한 최종 실패는 근태 관리자에게 알림으로
-      드러나야 한다 (메일이 안 온 것과 구분이 안 되면 안 된다)
-- [x] **퇴근 미처리 기록 — 탐지·노출 완료.** `workEndTime IS NULL`이면 `workingMinutes=0`으로 SUM에 들어간다.
-      1일 오전 배치면 전월 말일에 퇴근을 찍지 않은 직원이 그대로 0분 처리된다.
-      `countByWorkDateBetweenAndWorkEndTimeIsNull`로 건수를 세어 `OverTimeReport`에 싣고,
-      시트 첫 행에 경고로 남긴다(연차는 `workEndTime`이 채워지므로 오탐 없음).
-      → 남은 것은 **라우팅**: 건수가 0이 아닐 때 대표 발송을 막고 근태 관리자에게 보낼지 여부.
-      발송 경로가 생긴 뒤 결정한다
+- [x] 스케줄러 도입(프로젝트 첫 도입): `config/SchedulingConfig`(`@EnableScheduling`)와
+      `scheduler/OverTimeReportDispatchScheduler`(`@Profile("prod")`).
+      cron `zone = "Asia/Seoul"` 명시, "전월"은 주입된 `Clock`에서 파생.
+      `Clock` 빈이 `systemDefaultZone()`이라 cron zone 과 날짜 파생 zone 을 **둘 다** KST 로
+      못박아야 서버 TZ 가 UTC 일 때 대상 월이 한 달 밀리지 않는다(테스트가 고정)
+- [x] 배치는 컨트롤러를 타지 않고 서비스를 직접 호출한다.
+      **임시 파일 대신 메모리 버퍼**(`ByteArrayOutputStream`)로 바꿨다 — 지시의 의도인
+      "부분 파일 차단"은 동일하게 충족되고, 수백 KB 규모에 임시 파일은 잔여물·권한·정리
+      책임만 늘린다. 재검토 조건은 ADR 3 Step 3에 남겼다(첨부가 수 MB급이 되면 파일로 회귀)
+- [x] **발송 이력 테이블 `UNIQUE(target_year_month)`** — `V13__report_dispatch.sql`.
+      중복 발송 방지의 유일한 하드 보증이고 나머지는 그 위의 편의 계층이다
+- [x] **재시도가 원장을 대체한다**: 1~3일 × 하루 4회(06/10/14/18 KST) = 최대 12회.
+      이력 유니크와 `SENT` 종착 상태 덕에 성공 시 자동 중단, 멱등.
+      공휴일 프리플라이트는 두지 않았다 — 라이브 호출이 fail-closed 라 데이터 문제가
+      곧 `FAILED(HOLIDAY_DATA_UNAVAILABLE)`로 드러나고 재시도 대상이 된다
+- [x] **조용한 실패 차단** — 3일 20:00(마지막 시도 2시간 뒤) 별도 스케줄이 미발송을 점검해
+      근태 관리자에게 알린다. 이력이 아예 없으면 "스케줄러 미동작"으로 보고 알린다.
+      시도 로직에 "이번이 마지막인가" 조건을 섞지 않으려고 진입점을 분리했다
+- [x] **퇴근 미처리 기록 — 탐지·노출·라우팅 완료.** `workEndTime IS NULL`이면 `workingMinutes=0`으로
+      집계에 들어가 그 직원의 초과근무를 과소 집계한다(= 임금 미지급).
+      → **라우팅을 "막는 쪽"으로 확정**(ADR 3 Step 4): 미마감이 1건이라도 있으면 대표 발송을
+      보류하고, 근태 관리자에게 리포트 + 미마감 목록(`findUnclosedByWorkDateBetween`)을 보내
+      교정을 요청한다. 재시도 창 안에 마감하면 다음 시도에서 자동으로 대표에게 나간다.
+      엑셀 첫 행 경고만으로는 "대표가 경고를 읽었을 것"에 기대게 되므로 경고로 끝내지 않는다
+- [x] 수동 재실행 `POST /api/overtime/report/dispatch` (ManagerOnly) — 배치와 같은 멱등 경로.
+      강제 발송 플래그는 두지 않는다. 응답으로 현재 발송 상태를 돌려주어 관리자가 미마감을
+      고친 뒤 다음 재시도를 기다리지 않고 확인할 수 있다
 
 ## 5. 법정 산정 방식 정합
 
@@ -159,9 +167,15 @@
 
 ## 6. 마이너
 
-- [ ] `OverTimeService.calculateOverTime`에 `@Transactional(readOnly = true)` 부재 —
-      두 쿼리 사이 비일관 스냅샷 가능. 붙일 때는 외부 API 호출(`HolidayApiClient`)을
-      트랜잭션 밖으로 빼야 한다
-- [ ] 외부 API 타임아웃을 `application-*.yml`로 분리 (`RestTemplateConfig`의 기존 TODO)
+- [x] `OverTimeService.calculateOverTime`의 `@Transactional(readOnly = true)` (2026-08-11).
+      두 DB 조회를 `OverTimeSnapshotReader`(`@Transactional(readOnly = true)`)로 묶고
+      공휴일 라이브 호출은 그 밖에 남겼다. 별도 빈으로 뽑은 이유: 같은 클래스 안에서
+      `@Transactional` 메서드를 자기호출하면 프록시를 타지 않아 애초에 트랜잭션이 걸리지 않는다 —
+      트랜잭션 경계를 클래스 경계와 일치시켰다
+- [x] 외부 API 타임아웃을 `application-*.yml`로 분리 (2026-08-11).
+      `public.data.api.connectTimeout`/`readTimeout`(기본 3s/5s)으로 노출해
+      `PUBLIC_API_CONNECT_TIMEOUT`/`PUBLIC_API_READ_TIMEOUT`으로 재배포 없이 조정한다.
+      배치가 공휴일 API 에 매달리면 재시도 창을 통째로 잡아먹는다 — 온디맨드 조회와 달리
+      사람이 보고 있지 않다
 - [x] `HolidayResponse.Item.setLocDate` 오타 수정 (`setLocdate`, 필드와 일치 — 클라이언트
       분리에 딸려 처리)

--- a/build.gradle
+++ b/build.gradle
@@ -21,6 +21,7 @@ repositories {
 dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
+	implementation 'org.springframework.boot:spring-boot-starter-mail'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	implementation 'org.springframework.security:spring-security-crypto'
 	implementation 'org.flywaydb:flyway-core'

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -128,6 +128,16 @@ server:
 | `PUBLIC_API_SERVICE_KEY` | 공공데이터포털 키 | 미설정 시 부팅 실패 — 배포 전 발급 확인 |
 | `ADMIN_PASSWORD_HASH` | BCrypt 해시 | **신규** (§1-4) |
 | `SERVER_PORT` | 8080 (컨테이너 내부) | |
+| `MAIL_HOST` / `MAIL_PORT` / `MAIL_USERNAME` / `MAIL_PASSWORD` | 사내 SMTP 또는 Gmail 앱 비밀번호 | **신규** (ADR 3). prod 기본값 없음 — 미설정 시 부팅 실패 |
+| `MAIL_SMTP_AUTH` / `MAIL_SMTP_STARTTLS` | `true` | **신규**. 선택 — 미설정 시 둘 다 true |
+| `REPORT_MAIL_FROM` | 발신 주소 | **신규**. prod 기본값 없음 |
+| `REPORT_MAIL_CEO` | 대표 메일 | **신규**. 정상 리포트의 유일한 수신자 |
+| `REPORT_MAIL_MANAGERS` | 근태 관리자 메일 | **신규**. 쉼표 구분 복수 가능. 미마감 보류·발송 실패 알림 수신자 |
+| `PUBLIC_API_CONNECT_TIMEOUT` / `PUBLIC_API_READ_TIMEOUT` | `3s` / `5s` | **신규**. 선택 — 배치가 공휴일 API 에 매달려 재시도 창을 잡아먹지 않도록 재배포 없이 조정 |
+
+> 메일 설정에 기본값을 두지 않는 이유: 배치는 매월 1일에만 돈다. 값이 비어 있어도 앱이
+> 뜨면 한 달 뒤 "리포트가 안 왔다"로 발견되고, 그 시점엔 이미 급여 정산이 지나 있다.
+> `ADMIN_PASSWORD_HASH`와 같은 방침으로 부팅 시점에 실패시킨다.
 
 시크릿은 서버의 `.env`(gitignored) 또는 GitHub Actions Secrets로만 관리한다. docker-compose.yml의 로컬용 고정 비밀번호(`office_password` 등)를 운영에 재사용하지 않는다.
 
@@ -142,6 +152,10 @@ server:
 7. SPA 라우트(`/teams`, `/employees`, `/overtime`) 직접 접속/새로고침 정상 확인.
 8. `scripts/api_test.sh`를 운영 오리진으로 스모크 실행 (admin 자격증명은 새 값으로).
 9. DB 백업 크론 + 로그 로테이션(`logs/office-commute.log`, 설정상 100MB/30일) 동작 확인.
+10. 메일 설정 주입 확인 → `POST /api/overtime/report/dispatch?yearMonth=<지난달>`을 MANAGER 로 한 번 호출해
+    응답의 `status`가 `SENT`(또는 미마감이 있으면 `FAILED` + `UNCLOSED_COMMUTES`)로 나오는지 확인.
+    배치 첫 발화(다음 달 1일 06:00 KST)를 기다리지 않고 발송 경로 전체를 검증하는 방법이다.
+    이미 발송된 달이면 아무 일도 일어나지 않으므로(멱등) 스모크로 안전하다.
 
 ## 6. 배포 후 개선 로드맵 (권고 — 차단 아님)
 

--- a/frontend/src/api/schema.d.ts
+++ b/frontend/src/api/schema.d.ts
@@ -729,6 +729,53 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/overtime/report/dispatch": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * 월별 초과근무 리포트 수동 발송 (Manager Only)
+         * @description 매월 1~3일 배치와 **완전히 같은** 멱등 경로를 즉시 실행한다.
+         *     이미 발송된 달(`SENT`)에는 아무 일도 일어나지 않으며 강제 발송 플래그는 없다.
+         *     퇴근 미마감이 있으면 대표에게 보내지 않고 근태 관리자에게 교정 요청 메일이 나가며,
+         *     응답의 `status`는 `FAILED`, `lastFailureReason`은 `UNCLOSED_COMMUTES...`가 된다.
+         */
+        post: {
+            parameters: {
+                query: {
+                    /** @description ISO yyyy-MM */
+                    yearMonth: components["parameters"]["YearMonthQuery"];
+                };
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description 실행 후 현재 발송 상태 */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["OverTimeReportDispatchResponse"];
+                    };
+                };
+                401: components["responses"]["Unauthorized"];
+                403: components["responses"]["Forbidden"];
+            };
+        };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/overtime/report/excel": {
         parameters: {
             query?: never;
@@ -966,6 +1013,34 @@ export interface components {
             details: components["schemas"]["CommuteDetail"][];
             /** Format: int64 */
             sumWorkingMinutes: number;
+        };
+        OverTimeReportDispatchResponse: {
+            /**
+             * @description ISO yyyy-MM
+             * @example 2026-07
+             */
+            yearMonth: string;
+            /**
+             * @description IN_PROGRESS = 다른 실행이 선점 중, SENT = 대표에게 발송 완료(종착),
+             *     FAILED = 시도했으나 실패 — 재시도 창(1~3일) 안이면 다음 시도가 다시 집어간다
+             * @enum {string}
+             */
+            status: "IN_PROGRESS" | "SENT" | "FAILED";
+            /**
+             * Format: int32
+             * @description 결과가 기록된 시도 횟수
+             */
+            attemptCount: number;
+            /**
+             * Format: date-time
+             * @description 발송 완료 시각(SENT 일 때만)
+             */
+            sentAt?: string | null;
+            /**
+             * @description "분류: 상세" 형식. 분류는 UNCLOSED_COMMUTES / HOLIDAY_DATA_UNAVAILABLE /
+             *     MAIL_SEND_FAILED / UNEXPECTED
+             */
+            lastFailureReason?: string | null;
         };
         OverTimeCalculateResponse: {
             /** Format: int64 */

--- a/openapi.yml
+++ b/openapi.yml
@@ -375,6 +375,26 @@ paths:
             application/json:
               schema: { $ref: '#/components/schemas/ErrorResult' }
 
+  /api/overtime/report/dispatch:
+    post:
+      tags: [OverTime]
+      summary: 월별 초과근무 리포트 수동 발송 (Manager Only)
+      description: |
+        매월 1~3일 배치와 **완전히 같은** 멱등 경로를 즉시 실행한다.
+        이미 발송된 달(`SENT`)에는 아무 일도 일어나지 않으며 강제 발송 플래그는 없다.
+        퇴근 미마감이 있으면 대표에게 보내지 않고 근태 관리자에게 교정 요청 메일이 나가며,
+        응답의 `status`는 `FAILED`, `lastFailureReason`은 `UNCLOSED_COMMUTES...`가 된다.
+      parameters:
+        - $ref: '#/components/parameters/YearMonthQuery'
+      responses:
+        '200':
+          description: 실행 후 현재 발송 상태
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/OverTimeReportDispatchResponse' }
+        '401': { $ref: '#/components/responses/Unauthorized' }
+        '403': { $ref: '#/components/responses/Forbidden' }
+
   /api/overtime/report/excel:
     get:
       tags: [OverTime]
@@ -652,6 +672,26 @@ components:
         sumWorkingMinutes: { type: integer, format: int64 }
 
     # ---- OverTime ----
+    OverTimeReportDispatchResponse:
+      type: object
+      required: [yearMonth, status, attemptCount]
+      properties:
+        yearMonth: { type: string, example: "2026-07", description: ISO yyyy-MM }
+        status:
+          type: string
+          enum: [IN_PROGRESS, SENT, FAILED]
+          description: |
+            IN_PROGRESS = 다른 실행이 선점 중, SENT = 대표에게 발송 완료(종착),
+            FAILED = 시도했으나 실패 — 재시도 창(1~3일) 안이면 다음 시도가 다시 집어간다
+        attemptCount: { type: integer, format: int32, description: 결과가 기록된 시도 횟수 }
+        sentAt: { type: string, format: date-time, nullable: true, description: 발송 완료 시각(SENT 일 때만) }
+        lastFailureReason:
+          type: string
+          nullable: true
+          description: |
+            "분류: 상세" 형식. 분류는 UNCLOSED_COMMUTES / HOLIDAY_DATA_UNAVAILABLE /
+            MAIL_SEND_FAILED / UNEXPECTED
+
     OverTimeCalculateResponse:
       type: object
       required: [id, employeeCode, name, teamName, overTimeMinutes, holidayWithin8HoursMinutes, holidayExceeding8HoursMinutes]

--- a/src/main/java/com/company/officecommute/config/RestTemplateConfig.java
+++ b/src/main/java/com/company/officecommute/config/RestTemplateConfig.java
@@ -1,5 +1,6 @@
 package com.company.officecommute.config;
 
+import com.company.officecommute.web.HolidayApiProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.client.SimpleClientHttpRequestFactory;
@@ -10,18 +11,25 @@ import org.springframework.web.client.RestTemplate;
 import java.util.ArrayList;
 import java.util.List;
 
+/**
+ * 유일한 소비자는 {@code HolidayApiClient} 다. 따라서 타임아웃도 그 API 의 설정
+ * ({@code public.data.api.*}) 에서 읽는다 — 값이 yml/환경변수로 나와 있어 운영에서
+ * 재배포 없이 조정할 수 있다.
+ */
 @Configuration
 public class RestTemplateConfig {
 
-    // TODO: 운영에서는 외부 API 타임아웃 값을 application-*.yml 설정으로 분리해 배포 없이 조정할 수 있게 한다.
-    private static final int CONNECT_TIMEOUT_MS = 3000;
-    private static final int READ_TIMEOUT_MS = 5000;
+    private final HolidayApiProperties holidayApiProperties;
+
+    public RestTemplateConfig(HolidayApiProperties holidayApiProperties) {
+        this.holidayApiProperties = holidayApiProperties;
+    }
 
     @Bean
     public RestTemplate restTemplate() {
         SimpleClientHttpRequestFactory factory = new SimpleClientHttpRequestFactory();
-        factory.setConnectTimeout(CONNECT_TIMEOUT_MS);
-        factory.setReadTimeout(READ_TIMEOUT_MS);
+        factory.setConnectTimeout(holidayApiProperties.getConnectTimeout());
+        factory.setReadTimeout(holidayApiProperties.getReadTimeout());
 
         RestTemplate restTemplate = new RestTemplate(factory);
 

--- a/src/main/java/com/company/officecommute/config/SchedulingConfig.java
+++ b/src/main/java/com/company/officecommute/config/SchedulingConfig.java
@@ -1,0 +1,16 @@
+package com.company.officecommute.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableScheduling;
+
+/**
+ * 프로젝트의 첫 스케줄러 도입.
+ * <p>
+ * {@code @SpringBootApplication}에 붙이지 않고 별도 설정으로 분리한다 — 배치 활성화가
+ * 애플리케이션 부트스트랩과 한 덩어리가 되면 끄고 켜는 지점이 사라진다.
+ * 실제 배치 빈은 {@code @Profile("prod")}라 dev/test 에서는 등록되지 않는다.
+ */
+@Configuration
+@EnableScheduling
+public class SchedulingConfig {
+}

--- a/src/main/java/com/company/officecommute/controller/overtime/OverTimeController.java
+++ b/src/main/java/com/company/officecommute/controller/overtime/OverTimeController.java
@@ -3,6 +3,7 @@ package com.company.officecommute.controller.overtime;
 import com.company.officecommute.auth.ManagerOnly;
 import com.company.officecommute.dto.overtime.response.OverTimeCalculateResponse;
 import com.company.officecommute.dto.overtime.response.OverTimeReport;
+import com.company.officecommute.service.overtime.OverTimeReportFileName;
 import com.company.officecommute.service.overtime.OverTimeReportService;
 import com.company.officecommute.service.overtime.OverTimeService;
 import org.springframework.http.ContentDisposition;
@@ -51,7 +52,7 @@ public class OverTimeController {
 
         HttpHeaders headers = new HttpHeaders();
         headers.setContentType(MediaType.parseMediaType("application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"));
-        headers.setContentDisposition(ContentDisposition.attachment().filename(yearMonth.getYear() + "년" + yearMonth.getMonthValue() + "월_초과근무보고서.xlsx", UTF_8).build());
+        headers.setContentDisposition(ContentDisposition.attachment().filename(OverTimeReportFileName.of(yearMonth), UTF_8).build());
         return ResponseEntity.ok()
                 .headers(headers)
                 .body(body);

--- a/src/main/java/com/company/officecommute/controller/overtime/OverTimeController.java
+++ b/src/main/java/com/company/officecommute/controller/overtime/OverTimeController.java
@@ -3,14 +3,17 @@ package com.company.officecommute.controller.overtime;
 import com.company.officecommute.auth.ManagerOnly;
 import com.company.officecommute.dto.overtime.response.OverTimeCalculateResponse;
 import com.company.officecommute.dto.overtime.response.OverTimeReport;
+import com.company.officecommute.dto.report.response.OverTimeReportDispatchResponse;
 import com.company.officecommute.service.overtime.OverTimeReportFileName;
 import com.company.officecommute.service.overtime.OverTimeReportService;
 import com.company.officecommute.service.overtime.OverTimeService;
+import com.company.officecommute.service.report.OverTimeReportDispatchService;
 import org.springframework.http.ContentDisposition;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
@@ -27,19 +30,32 @@ public class OverTimeController {
 
     private final OverTimeService overTimeService;
     private final OverTimeReportService overTimeReportService;
+    private final OverTimeReportDispatchService overTimeReportDispatchService;
 
     public OverTimeController(
             OverTimeService overTimeService,
-            OverTimeReportService overTimeReportService
+            OverTimeReportService overTimeReportService,
+            OverTimeReportDispatchService overTimeReportDispatchService
     ) {
         this.overTimeService = overTimeService;
         this.overTimeReportService = overTimeReportService;
+        this.overTimeReportDispatchService = overTimeReportDispatchService;
     }
 
     @ManagerOnly
     @GetMapping("/overtime")
     public List<OverTimeCalculateResponse> calculateOverTime(@RequestParam YearMonth yearMonth) {
         return overTimeService.calculateOverTime(yearMonth);
+    }
+
+    /**
+     * 수동 재실행. 배치와 같은 멱등 경로라 이미 발송된 달에는 아무 일도 일어나지 않는다.
+     * 관리자가 미마감을 고친 뒤 다음 재시도(최대 4시간 뒤)를 기다리지 않아도 되게 한다.
+     */
+    @ManagerOnly
+    @PostMapping("/overtime/report/dispatch")
+    public OverTimeReportDispatchResponse dispatchOverTimeReport(@RequestParam YearMonth yearMonth) {
+        return overTimeReportDispatchService.dispatchAndDescribe(yearMonth);
     }
 
     @ManagerOnly

--- a/src/main/java/com/company/officecommute/domain/report/DispatchFailureReason.java
+++ b/src/main/java/com/company/officecommute/domain/report/DispatchFailureReason.java
@@ -1,0 +1,30 @@
+package com.company.officecommute.domain.report;
+
+/**
+ * 발송 실패의 분류. 재시도가 의미를 가지려면 관리자가 "무엇을 고쳐야 하는지" 또는
+ * "고칠 것이 없으니 기다리면 되는지"를 알아야 하므로, 실패를 뭉뚱그리지 않고 나눈다.
+ */
+public enum DispatchFailureReason {
+
+    /** 퇴근 미마감 기록이 있어 대표 발송을 보류했다. 마감하면 다음 재시도에서 자동 발송된다. */
+    UNCLOSED_COMMUTES("퇴근 미마감 기록이 있어 발송을 보류했습니다. 마감하면 다음 재시도에서 자동 발송됩니다."),
+
+    /** 공휴일 API가 응답하지 않아 집계를 신뢰할 수 없다. 사람이 할 조치는 없다. */
+    HOLIDAY_DATA_UNAVAILABLE("공휴일 API를 이용할 수 없어 집계를 중단했습니다. 조치 없이 재시도됩니다."),
+
+    /** SMTP 오류. 계정·서버 설정을 봐야 한다. */
+    MAIL_SEND_FAILED("메일 발송에 실패했습니다. SMTP 계정과 서버 설정을 확인해 주세요."),
+
+    /** 그 외. 스택 트레이스는 로그에 남는다. */
+    UNEXPECTED("예상하지 못한 오류로 발송에 실패했습니다. 서버 로그를 확인해 주세요.");
+
+    private final String managerGuidance;
+
+    DispatchFailureReason(String managerGuidance) {
+        this.managerGuidance = managerGuidance;
+    }
+
+    public String getManagerGuidance() {
+        return managerGuidance;
+    }
+}

--- a/src/main/java/com/company/officecommute/domain/report/DispatchStatus.java
+++ b/src/main/java/com/company/officecommute/domain/report/DispatchStatus.java
@@ -1,0 +1,13 @@
+package com.company.officecommute.domain.report;
+
+public enum DispatchStatus {
+
+    /** 어떤 실행이 이 달을 선점해 진행 중이다. 리스 시간이 지나면 회수 대상이 된다. */
+    IN_PROGRESS,
+
+    /** 대표에게 발송 완료. 종착 상태 — 이 달은 다시 발송되지 않는다. */
+    SENT,
+
+    /** 시도했으나 실패. 재시도 창 안이면 다음 시도가 다시 집어간다. */
+    FAILED
+}

--- a/src/main/java/com/company/officecommute/domain/report/ReportDispatch.java
+++ b/src/main/java/com/company/officecommute/domain/report/ReportDispatch.java
@@ -1,0 +1,144 @@
+package com.company.officecommute.domain.report;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Convert;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.time.YearMonth;
+import java.util.Objects;
+
+/**
+ * 한 대상 월의 발송 이력. 상태 전이를 엔티티가 소유해, "어디선가 status 만 바꿔치기"가
+ * 생기지 않게 한다.
+ * <p>
+ * {@code UNIQUE(target_year_month)}가 중복 발송 방지의 유일한 하드 보증이다.
+ */
+@Entity
+@Table(uniqueConstraints = {
+        @UniqueConstraint(name = "uk_report_dispatch_year_month", columnNames = {"target_year_month"})
+})
+public class ReportDispatch {
+
+    /** 실패 사유 컬럼 길이. 넘치면 저장 시점에 터지므로 자른다. */
+    private static final int MAX_FAILURE_REASON_LENGTH = 1000;
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long reportDispatchId;
+
+    @Convert(converter = YearMonthAttributeConverter.class)
+    @Column(name = "target_year_month", nullable = false, length = 7)
+    private YearMonth targetYearMonth;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 20)
+    private DispatchStatus status;
+
+    /** 결과가 기록된 시도 횟수. 진행 중인 시도는 아직 세지 않는다. */
+    @Column(nullable = false)
+    private int attemptCount;
+
+    @Column(nullable = false)
+    private Instant lastAttemptedAt;
+
+    private Instant sentAt;
+
+    @Column(length = MAX_FAILURE_REASON_LENGTH)
+    private String lastFailureReason;
+
+    protected ReportDispatch() {
+    }
+
+    private ReportDispatch(YearMonth targetYearMonth, Instant now) {
+        this.targetYearMonth = Objects.requireNonNull(targetYearMonth, "targetYearMonth는 null일 수 없습니다.");
+        this.status = DispatchStatus.IN_PROGRESS;
+        this.attemptCount = 0;
+        this.lastAttemptedAt = Objects.requireNonNull(now, "now는 null일 수 없습니다.");
+    }
+
+    /** 이 달을 선점한다. 동시에 두 실행이 부르면 유니크 제약이 한쪽을 떨어뜨린다. */
+    public static ReportDispatch claim(YearMonth targetYearMonth, Instant now) {
+        return new ReportDispatch(targetYearMonth, now);
+    }
+
+    /**
+     * 이미 있는 이력으로 새 시도를 시작한다(재시도 또는 리스 회수).
+     * 실패 사유는 남겨 둔다 — 이번 시도가 또 실패할 때까지는 마지막으로 알려진 이유가 유효하다.
+     */
+    public void beginAttempt(Instant now) {
+        this.status = DispatchStatus.IN_PROGRESS;
+        this.lastAttemptedAt = now;
+    }
+
+    public void markSent(Instant now) {
+        this.status = DispatchStatus.SENT;
+        this.sentAt = now;
+        this.lastAttemptedAt = now;
+        this.attemptCount++;
+        this.lastFailureReason = null;
+    }
+
+    public void markFailed(String reason, Instant now) {
+        this.status = DispatchStatus.FAILED;
+        this.lastAttemptedAt = now;
+        this.attemptCount++;
+        this.lastFailureReason = truncate(reason);
+    }
+
+    public boolean isSent() {
+        return status == DispatchStatus.SENT;
+    }
+
+    /**
+     * 다른 실행이 선점한 채 아직 살아 있는가.
+     * 발송 도중 프로세스가 죽으면 {@code IN_PROGRESS}가 남는데, 리스가 없으면 그 달이
+     * 영원히 잠긴다 — 리스 시간이 지난 선점은 회수한다.
+     */
+    public boolean isLeaseHeld(Instant now, Duration lease) {
+        return status == DispatchStatus.IN_PROGRESS && lastAttemptedAt.plus(lease).isAfter(now);
+    }
+
+    private String truncate(String reason) {
+        if (reason == null || reason.length() <= MAX_FAILURE_REASON_LENGTH) {
+            return reason;
+        }
+        return reason.substring(0, MAX_FAILURE_REASON_LENGTH);
+    }
+
+    public Long getReportDispatchId() {
+        return reportDispatchId;
+    }
+
+    public YearMonth getTargetYearMonth() {
+        return targetYearMonth;
+    }
+
+    public DispatchStatus getStatus() {
+        return status;
+    }
+
+    public int getAttemptCount() {
+        return attemptCount;
+    }
+
+    public Instant getLastAttemptedAt() {
+        return lastAttemptedAt;
+    }
+
+    public Instant getSentAt() {
+        return sentAt;
+    }
+
+    public String getLastFailureReason() {
+        return lastFailureReason;
+    }
+}

--- a/src/main/java/com/company/officecommute/domain/report/YearMonthAttributeConverter.java
+++ b/src/main/java/com/company/officecommute/domain/report/YearMonthAttributeConverter.java
@@ -1,0 +1,25 @@
+package com.company.officecommute.domain.report;
+
+import jakarta.persistence.AttributeConverter;
+import jakarta.persistence.Converter;
+
+import java.time.YearMonth;
+
+/**
+ * {@code YearMonth} ↔ {@code CHAR(7)} 'yyyy-MM'.
+ * {@link YearMonth#toString()}과 {@link YearMonth#parse(CharSequence)}가 이미 ISO 'yyyy-MM'
+ * 라운드트립을 보장하므로 별도 포맷터를 두지 않는다.
+ */
+@Converter
+public class YearMonthAttributeConverter implements AttributeConverter<YearMonth, String> {
+
+    @Override
+    public String convertToDatabaseColumn(YearMonth attribute) {
+        return attribute == null ? null : attribute.toString();
+    }
+
+    @Override
+    public YearMonth convertToEntityAttribute(String dbData) {
+        return dbData == null ? null : YearMonth.parse(dbData);
+    }
+}

--- a/src/main/java/com/company/officecommute/dto/report/response/OverTimeReportDispatchResponse.java
+++ b/src/main/java/com/company/officecommute/dto/report/response/OverTimeReportDispatchResponse.java
@@ -1,0 +1,29 @@
+package com.company.officecommute.dto.report.response;
+
+import com.company.officecommute.domain.report.DispatchStatus;
+import com.company.officecommute.domain.report.ReportDispatch;
+
+import java.time.Instant;
+import java.time.YearMonth;
+
+/**
+ * 수동 재실행의 응답. 관리자가 미마감을 고친 뒤 다음 재시도를 기다리지 않고
+ * 결과를 즉시 확인할 수 있어야 하므로, 현재 발송 상태를 그대로 돌려준다.
+ */
+public record OverTimeReportDispatchResponse(
+        YearMonth yearMonth,
+        DispatchStatus status,
+        int attemptCount,
+        Instant sentAt,
+        String lastFailureReason
+) {
+    public static OverTimeReportDispatchResponse from(ReportDispatch dispatch) {
+        return new OverTimeReportDispatchResponse(
+                dispatch.getTargetYearMonth(),
+                dispatch.getStatus(),
+                dispatch.getAttemptCount(),
+                dispatch.getSentAt(),
+                dispatch.getLastFailureReason()
+        );
+    }
+}

--- a/src/main/java/com/company/officecommute/mail/ReportMailException.java
+++ b/src/main/java/com/company/officecommute/mail/ReportMailException.java
@@ -1,0 +1,16 @@
+package com.company.officecommute.mail;
+
+/**
+ * 메일 구성·설정 문제. 발송 유스케이스는 이것을 {@code MAIL_SEND_FAILED}로 분류해
+ * 실패로 기록한다 — 스케줄러 스레드를 죽이지 않는다.
+ */
+public class ReportMailException extends RuntimeException {
+
+    public ReportMailException(String message) {
+        super(message);
+    }
+
+    public ReportMailException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/src/main/java/com/company/officecommute/mail/ReportMailProperties.java
+++ b/src/main/java/com/company/officecommute/mail/ReportMailProperties.java
@@ -1,0 +1,48 @@
+package com.company.officecommute.mail;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+
+import java.util.List;
+
+/**
+ * 수신자·발신자는 전부 설정값이다. 코드에 박으면 사람이 바뀔 때마다 재배포가 필요하고,
+ * 저장소에 실주소가 남는다.
+ */
+@Configuration
+@ConfigurationProperties(prefix = "report.mail")
+public class ReportMailProperties {
+
+    /** 발신 주소. */
+    private String from;
+
+    /** 대표 — 정상 리포트의 유일한 수신자. */
+    private String ceo;
+
+    /** 근태 관리자 — 보류·실패 알림 수신자. 복수 가능(쉼표 구분 환경변수). */
+    private List<String> managers = List.of();
+
+    public String getFrom() {
+        return from;
+    }
+
+    public void setFrom(String from) {
+        this.from = from;
+    }
+
+    public String getCeo() {
+        return ceo;
+    }
+
+    public void setCeo(String ceo) {
+        this.ceo = ceo;
+    }
+
+    public List<String> getManagers() {
+        return managers;
+    }
+
+    public void setManagers(List<String> managers) {
+        this.managers = List.copyOf(managers);
+    }
+}

--- a/src/main/java/com/company/officecommute/mail/ReportMailer.java
+++ b/src/main/java/com/company/officecommute/mail/ReportMailer.java
@@ -1,0 +1,178 @@
+package com.company.officecommute.mail;
+
+import com.company.officecommute.domain.report.DispatchFailureReason;
+import com.company.officecommute.dto.overtime.response.OverTimeReport;
+import com.company.officecommute.service.overtime.OverTimeReportFileName;
+import com.company.officecommute.service.overtime.UnclosedCommute;
+import jakarta.mail.internet.MimeMessage;
+import org.springframework.core.io.ByteArrayResource;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.mail.javamail.MimeMessageHelper;
+import org.springframework.stereotype.Component;
+
+import java.time.YearMonth;
+import java.util.List;
+
+/**
+ * 초과근무 리포트 관련 메일 발송.
+ * <p>
+ * 용도별로 메서드를 나눈다 — 수신자·제목·본문이 전부 다르므로 플래그 인자로 분기하면
+ * "대표에게 갈 메일이 관리자에게 가는" 종류의 실수가 한 줄 조건문 뒤로 숨는다.
+ */
+@Component
+public class ReportMailer {
+
+    private static final String SUBJECT_PREFIX = "[초과근무] ";
+    private static final String CALCULATION_BASIS = "1일 8시간·1주 40시간 초과, 휴일근로 별도 트랙";
+
+    /** 본문이 무한정 길어지는 것을 막는다. 전체 목록은 첨부 리포트와 화면에서 확인한다. */
+    private static final int MAX_LISTED_UNCLOSED = 50;
+
+    private final JavaMailSender mailSender;
+    private final ReportMailProperties properties;
+
+    public ReportMailer(JavaMailSender mailSender, ReportMailProperties properties) {
+        this.mailSender = mailSender;
+        this.properties = properties;
+    }
+
+    /**
+     * 정상 리포트 — 대표에게. 이 메일이 나가는 경우는 미마감 0건뿐이다.
+     */
+    public void sendMonthlyReport(OverTimeReport report, byte[] excel) {
+        String body = """
+                %s 초과근무 보고서를 첨부합니다.
+
+                %s
+                """.formatted(displayMonth(report.yearMonth()), summary(report));
+
+        send(
+                List.of(requireConfigured(properties.getCeo(), "report.mail.ceo")),
+                SUBJECT_PREFIX + displayMonth(report.yearMonth()) + " 초과근무 보고서",
+                body,
+                report.yearMonth(),
+                excel
+        );
+    }
+
+    /**
+     * 퇴근 미마감으로 대표 발송을 보류했음 — 근태 관리자에게.
+     * 리포트를 함께 첨부해 관리자가 수치를 바로 확인하고 교정할 수 있게 한다.
+     */
+    public void sendUnclosedCommuteWarning(OverTimeReport report, byte[] excel, List<UnclosedCommute> unclosed) {
+        String body = """
+                %s 초과근무 리포트의 대표 발송을 보류했습니다.
+
+                %s
+
+                %s
+
+                %s
+                """.formatted(
+                displayMonth(report.yearMonth()),
+                DispatchFailureReason.UNCLOSED_COMMUTES.getManagerGuidance(),
+                summary(report),
+                unclosedList(unclosed)
+        );
+
+        send(
+                managers(),
+                SUBJECT_PREFIX + displayMonth(report.yearMonth()) + " 리포트 발송 보류 — 퇴근 미마감 "
+                        + report.unclosedCommuteCount() + "건",
+                body,
+                report.yearMonth(),
+                excel
+        );
+    }
+
+    /**
+     * 발송 실패 — 근태 관리자에게. "메일이 안 온 것"과 "발송이 실패한 것"이 구분돼야 한다.
+     */
+    public void sendDispatchFailure(YearMonth target, DispatchFailureReason reason, String detail) {
+        String body = """
+                %s 초과근무 리포트 발송이 실패했습니다.
+
+                사유: %s
+                %s
+
+                상세: %s
+                """.formatted(displayMonth(target), reason.name(), reason.getManagerGuidance(), detail);
+
+        send(
+                managers(),
+                SUBJECT_PREFIX + displayMonth(target) + " 리포트 발송 실패 — " + reason.name(),
+                body,
+                target,
+                null
+        );
+    }
+
+    private void send(List<String> recipients, String subject, String body, YearMonth target, byte[] excel) {
+        MimeMessage message = mailSender.createMimeMessage();
+        try {
+            MimeMessageHelper helper = new MimeMessageHelper(message, true, "UTF-8");
+            helper.setFrom(requireConfigured(properties.getFrom(), "report.mail.from"));
+            helper.setTo(recipients.toArray(new String[0]));
+            helper.setSubject(subject);
+            helper.setText(body, false);
+            if (excel != null) {
+                helper.addAttachment(OverTimeReportFileName.of(target), new ByteArrayResource(excel));
+            }
+        } catch (jakarta.mail.MessagingException e) {
+            throw new ReportMailException("메일 구성에 실패했습니다: " + subject, e);
+        }
+        mailSender.send(message);
+    }
+
+    private List<String> managers() {
+        List<String> managers = properties.getManagers();
+        if (managers.isEmpty()) {
+            // 관리자 주소가 비면 "조용한 실패"를 드러낼 통로 자체가 없어진다 — 설정 누락으로 다룬다.
+            throw new ReportMailException("report.mail.managers 가 비어 있어 관리자 알림을 보낼 수 없습니다.");
+        }
+        return managers;
+    }
+
+    private String requireConfigured(String value, String propertyName) {
+        if (value == null || value.isBlank()) {
+            throw new ReportMailException(propertyName + " 가 설정되지 않았습니다.");
+        }
+        return value;
+    }
+
+    /**
+     * 수신자가 첨부를 열지 않고도 신뢰성을 판단할 수 있어야 한다.
+     */
+    private String summary(OverTimeReport report) {
+        return """
+                - 대상 월: %s
+                - 대상자: %d명
+                - 퇴근 미마감: %d건
+                - 산정 기준: %s""".formatted(
+                displayMonth(report.yearMonth()),
+                report.rows().size(),
+                report.unclosedCommuteCount(),
+                CALCULATION_BASIS
+        );
+    }
+
+    private String unclosedList(List<UnclosedCommute> unclosed) {
+        StringBuilder builder = new StringBuilder("미마감 목록 (")
+                .append(unclosed.size())
+                .append("건)");
+        unclosed.stream()
+                .limit(MAX_LISTED_UNCLOSED)
+                .forEach(record -> builder.append("\n- ")
+                        .append(record.employeeCode()).append(' ')
+                        .append(record.employeeName()).append(' ')
+                        .append(record.workDate()));
+        if (unclosed.size() > MAX_LISTED_UNCLOSED) {
+            builder.append("\n- ... 외 ").append(unclosed.size() - MAX_LISTED_UNCLOSED).append("건");
+        }
+        return builder.toString();
+    }
+
+    private String displayMonth(YearMonth yearMonth) {
+        return yearMonth.getYear() + "년 " + yearMonth.getMonthValue() + "월";
+    }
+}

--- a/src/main/java/com/company/officecommute/repository/commute/CommuteHistoryRepository.java
+++ b/src/main/java/com/company/officecommute/repository/commute/CommuteHistoryRepository.java
@@ -2,6 +2,7 @@ package com.company.officecommute.repository.commute;
 
 import com.company.officecommute.domain.commute.CommuteHistory;
 import com.company.officecommute.service.overtime.DailyWorkingMinutes;
+import com.company.officecommute.service.overtime.UnclosedCommute;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
@@ -32,6 +33,26 @@ public interface CommuteHistoryRepository extends JpaRepository<CommuteHistory, 
      * 연차 기록({@code registerAnnualLeave})은 {@code workEndTime}이 채워지므로 여기 잡히지 않는다.
      */
     long countByWorkDateBetweenAndWorkEndTimeIsNull(LocalDate startDate, LocalDate endDate);
+
+    /**
+     * 위 건수와 <b>같은 범위</b>의 미마감 기록 목록. 관리자에게 "무엇을 마감해야 하는지"를
+     * 알리려면 건수만으로는 부족하다.
+     * <p>
+     * 범위가 {@link #countByWorkDateBetweenAndWorkEndTimeIsNull}와 어긋나면
+     * "건수는 3건인데 목록은 2건" 같은 모순이 나오므로, 두 호출의 인자는 한 곳
+     * ({@code OverTimeService})에서만 만든다.
+     */
+    @Query("""
+            SELECT new com.company.officecommute.service.overtime.UnclosedCommute(
+                        e.employeeCode, e.name, ch.workDate
+                    )
+            FROM CommuteHistory ch, Employee e
+            WHERE e.employeeId = ch.employeeId
+                AND ch.workDate BETWEEN :startDate AND :endDate
+                AND ch.workEndTime IS NULL
+            ORDER BY ch.workDate, e.employeeCode
+            """)
+    List<UnclosedCommute> findUnclosedByWorkDateBetween(LocalDate startDate, LocalDate endDate);
 
     /**
      * 퇴근 처리. {@code workEndTime IS NULL} 조건으로 상태 확인과 변경을 단일 UPDATE로 묶어,

--- a/src/main/java/com/company/officecommute/repository/report/ReportDispatchRepository.java
+++ b/src/main/java/com/company/officecommute/repository/report/ReportDispatchRepository.java
@@ -1,0 +1,12 @@
+package com.company.officecommute.repository.report;
+
+import com.company.officecommute.domain.report.ReportDispatch;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.time.YearMonth;
+import java.util.Optional;
+
+public interface ReportDispatchRepository extends JpaRepository<ReportDispatch, Long> {
+
+    Optional<ReportDispatch> findByTargetYearMonth(YearMonth targetYearMonth);
+}

--- a/src/main/java/com/company/officecommute/scheduler/OverTimeReportDispatchScheduler.java
+++ b/src/main/java/com/company/officecommute/scheduler/OverTimeReportDispatchScheduler.java
@@ -1,0 +1,63 @@
+package com.company.officecommute.scheduler;
+
+import com.company.officecommute.service.report.OverTimeReportDispatchService;
+import org.springframework.context.annotation.Profile;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import java.time.Clock;
+import java.time.LocalDate;
+import java.time.YearMonth;
+import java.time.ZoneId;
+
+/**
+ * 매월 1일 오전 전월 리포트를 대표에게 보낸다.
+ * <p>
+ * {@code @Profile("prod")}라 dev/test 에서는 빈 자체가 만들어지지 않는다 — 켜고 끄는
+ * 플래그를 따로 둘 필요가 없고, 테스트 컨텍스트가 실수로 메일을 보낼 경로도 없다.
+ * <p>
+ * 발송 로직은 전부 {@link OverTimeReportDispatchService}에 있다. 이 클래스는 "언제"만 안다.
+ */
+@Component
+@Profile("prod")
+public class OverTimeReportDispatchScheduler {
+
+    /**
+     * 주입된 {@code Clock}은 {@code systemDefaultZone()}이라 서버 타임존에 따라 달이 밀릴 수 있다.
+     * (예: 9/1 06:00 KST는 UTC로 8/31 21:00 — 서버 TZ가 UTC면 "전월"이 7월이 된다.)
+     * cron 의 {@code zone}과 날짜 파생 zone을 <b>둘 다</b> KST로 못박아 서버 TZ와 무관하게
+     * 같은 달을 가리키게 한다.
+     */
+    private static final ZoneId KST = ZoneId.of("Asia/Seoul");
+
+    private final OverTimeReportDispatchService dispatchService;
+    private final Clock clock;
+
+    public OverTimeReportDispatchScheduler(OverTimeReportDispatchService dispatchService, Clock clock) {
+        this.dispatchService = dispatchService;
+        this.clock = clock;
+    }
+
+    /**
+     * 1~3일 × 하루 4회 = 최대 12회 시도. 첫 시도는 1일 06:00 KST.
+     * <p>
+     * 재시도가 공휴일 원장(저장 계층)을 대체한다 — API 다운은 리포트 실패가 아니라 지연이 되고,
+     * 발송 이력의 유니크 제약 덕에 성공하는 순간 나머지 시도는 자동으로 무해해진다.
+     */
+    @Scheduled(cron = "0 0 6,10,14,18 1-3 * *", zone = "Asia/Seoul")
+    public void dispatchPreviousMonth() {
+        dispatchService.dispatch(previousMonth());
+    }
+
+    /**
+     * 마지막 시도(3일 18:00) 2시간 뒤. 이 시점에 미발송이면 사람에게 드러내야 한다.
+     */
+    @Scheduled(cron = "0 0 20 3 * *", zone = "Asia/Seoul")
+    public void alertIfPreviousMonthNotSent() {
+        dispatchService.alertIfNotSent(previousMonth());
+    }
+
+    YearMonth previousMonth() {
+        return YearMonth.from(LocalDate.now(clock.withZone(KST))).minusMonths(1);
+    }
+}

--- a/src/main/java/com/company/officecommute/service/overtime/OverTimeReportFileName.java
+++ b/src/main/java/com/company/officecommute/service/overtime/OverTimeReportFileName.java
@@ -1,0 +1,18 @@
+package com.company.officecommute.service.overtime;
+
+import java.time.YearMonth;
+
+/**
+ * 초과근무 보고서 엑셀 파일명. 온디맨드 다운로드(컨트롤러)와 매월 배치 메일 첨부가
+ * <b>같은 이름</b>을 내보내야 대표·관리자가 두 경로에서 받은 파일을 같은 것으로 식별한다.
+ * 양쪽에 문자열을 따로 두면 한쪽만 바뀌는 순간 조용히 갈라지므로 한 곳에서만 만든다.
+ */
+public final class OverTimeReportFileName {
+
+    private OverTimeReportFileName() {
+    }
+
+    public static String of(YearMonth yearMonth) {
+        return yearMonth.getYear() + "년" + yearMonth.getMonthValue() + "월_초과근무보고서.xlsx";
+    }
+}

--- a/src/main/java/com/company/officecommute/service/overtime/OverTimeService.java
+++ b/src/main/java/com/company/officecommute/service/overtime/OverTimeService.java
@@ -2,7 +2,6 @@ package com.company.officecommute.service.overtime;
 
 import com.company.officecommute.dto.overtime.response.OverTimeCalculateResponse;
 import com.company.officecommute.repository.commute.CommuteHistoryRepository;
-import com.company.officecommute.repository.employee.EmployeeRepository;
 import com.company.officecommute.web.HolidayApiClient;
 import org.springframework.stereotype.Service;
 
@@ -20,16 +19,16 @@ public class OverTimeService {
     private static final String UNASSIGNED_TEAM_NAME = "미배정";
 
     private final CommuteHistoryRepository commuteHistoryRepository;
-    private final EmployeeRepository employeeRepository;
+    private final OverTimeSnapshotReader overTimeSnapshotReader;
     private final HolidayApiClient holidayApiClient;
 
     public OverTimeService(
             CommuteHistoryRepository commuteHistoryRepository,
-            EmployeeRepository employeeRepository,
+            OverTimeSnapshotReader overTimeSnapshotReader,
             HolidayApiClient holidayApiClient
     ) {
         this.commuteHistoryRepository = commuteHistoryRepository;
-        this.employeeRepository = employeeRepository;
+        this.overTimeSnapshotReader = overTimeSnapshotReader;
         this.holidayApiClient = holidayApiClient;
     }
 
@@ -55,21 +54,23 @@ public class OverTimeService {
         );
     }
 
+    /**
+     * 공휴일 조회는 외부 API 라이브 호출이라 <b>읽기 트랜잭션 밖</b>에 둔다.
+     * DB 스냅샷 안에 넣으면 외부 API 응답 시간만큼 커넥션을 붙잡고, 그 API 가 느려지는 날
+     * 커넥션 풀이 먼저 마른다. 두 DB 조회의 일관성은
+     * {@link OverTimeSnapshotReader}가 하나의 읽기 트랜잭션으로 보장한다.
+     */
     public List<OverTimeCalculateResponse> calculateOverTime(YearMonth yearMonth) {
-        // 대상 월 1일이 속한 주(월~일)의 월요일부터 조회 — 그 주의 40시간 판정에 전월 말 기록이 필요하다
-        LocalDate rangeStart = MonthlyOverTimeCalculator.requiredRangeStart(yearMonth);
-        LocalDate rangeEnd = yearMonth.atEndOfMonth();
+        Set<LocalDate> holidays = findHolidays(yearMonth);
+        OverTimeSnapshot snapshot = overTimeSnapshotReader.read(yearMonth);
 
-        Set<LocalDate> holidays = findHolidays(yearMonth, rangeStart);
-        Map<Long, Map<LocalDate, Long>> workingMinutesByEmployee =
-                commuteHistoryRepository.findDailyWorkingMinutesByWorkDateBetween(rangeStart, rangeEnd).stream()
-                        .collect(Collectors.groupingBy(
-                                DailyWorkingMinutes::employeeId,
-                                Collectors.toMap(DailyWorkingMinutes::workDate, DailyWorkingMinutes::workingMinutes)
-                        ));
+        Map<Long, Map<LocalDate, Long>> workingMinutesByEmployee = snapshot.dailyWorkingMinutes().stream()
+                .collect(Collectors.groupingBy(
+                        DailyWorkingMinutes::employeeId,
+                        Collectors.toMap(DailyWorkingMinutes::workDate, DailyWorkingMinutes::workingMinutes)
+                ));
 
-        // 대상자 판정은 월 경계 기준 — 스필오버 주(전월 말)의 근무는 그 직원의 전월 리포트가 이미 집계했다
-        return employeeRepository.findAllWithTeamEmployedBetween(yearMonth.atDay(1), rangeEnd).stream()
+        return snapshot.employees().stream()
                 .map(employee -> {
                     MonthlyOverTime overTime = MonthlyOverTimeCalculator.calculate(
                             yearMonth,
@@ -89,9 +90,12 @@ public class OverTimeService {
                 .toList();
     }
 
-    private Set<LocalDate> findHolidays(YearMonth yearMonth, LocalDate rangeStart) {
+    /**
+     * 대상 월 1일이 속한 주가 전월에 걸치면 전월 공휴일도 필요하다 — 그 주의 휴일근로 분류에 쓰인다.
+     */
+    private Set<LocalDate> findHolidays(YearMonth yearMonth) {
         Set<LocalDate> holidays = new HashSet<>(holidayApiClient.getHolidays(yearMonth));
-        YearMonth firstWeekMonth = YearMonth.from(rangeStart);
+        YearMonth firstWeekMonth = YearMonth.from(MonthlyOverTimeCalculator.requiredRangeStart(yearMonth));
         if (!firstWeekMonth.equals(yearMonth)) {
             holidays.addAll(holidayApiClient.getHolidays(firstWeekMonth));
         }

--- a/src/main/java/com/company/officecommute/service/overtime/OverTimeService.java
+++ b/src/main/java/com/company/officecommute/service/overtime/OverTimeService.java
@@ -44,6 +44,17 @@ public class OverTimeService {
         );
     }
 
+    /**
+     * {@link #countUnclosedCommutes}와 <b>정확히 같은 범위</b>의 미마감 기록 목록.
+     * 관리자에게 교정을 요청하려면 건수가 아니라 "무엇을"이 필요하다.
+     * 두 메서드가 범위를 각자 계산하면 "건수는 3건인데 목록은 2건"이 되므로 한 곳에서만 만든다.
+     */
+    public List<UnclosedCommute> findUnclosedCommutes(YearMonth yearMonth) {
+        return commuteHistoryRepository.findUnclosedByWorkDateBetween(
+                MonthlyOverTimeCalculator.requiredRangeStart(yearMonth), yearMonth.atEndOfMonth()
+        );
+    }
+
     public List<OverTimeCalculateResponse> calculateOverTime(YearMonth yearMonth) {
         // 대상 월 1일이 속한 주(월~일)의 월요일부터 조회 — 그 주의 40시간 판정에 전월 말 기록이 필요하다
         LocalDate rangeStart = MonthlyOverTimeCalculator.requiredRangeStart(yearMonth);

--- a/src/main/java/com/company/officecommute/service/overtime/OverTimeSnapshot.java
+++ b/src/main/java/com/company/officecommute/service/overtime/OverTimeSnapshot.java
@@ -1,0 +1,16 @@
+package com.company.officecommute.service.overtime;
+
+import com.company.officecommute.domain.employee.Employee;
+
+import java.util.List;
+
+/**
+ * 한 번의 읽기 트랜잭션에서 함께 뜬 리포트 입력. 두 조회가 같은 스냅샷에서 나왔다는 사실을
+ * 타입으로 묶어 둔다 — 따로 부르면 그 사이의 출퇴근 기록 변경이 "직원은 있는데 근무 기록은
+ * 다른 시점" 같은 비일관을 만든다.
+ */
+public record OverTimeSnapshot(
+        List<Employee> employees,
+        List<DailyWorkingMinutes> dailyWorkingMinutes
+) {
+}

--- a/src/main/java/com/company/officecommute/service/overtime/OverTimeSnapshotReader.java
+++ b/src/main/java/com/company/officecommute/service/overtime/OverTimeSnapshotReader.java
@@ -1,0 +1,47 @@
+package com.company.officecommute.service.overtime;
+
+import com.company.officecommute.repository.commute.CommuteHistoryRepository;
+import com.company.officecommute.repository.employee.EmployeeRepository;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.time.YearMonth;
+
+/**
+ * 초과근무 계산이 필요로 하는 두 조회를 <b>하나의 읽기 트랜잭션</b>으로 묶는다.
+ * <p>
+ * 따로 부르면 두 쿼리 사이에 출퇴근 기록이나 직원 정보가 바뀌어 비일관 스냅샷이 나올 수 있다.
+ * 급여 근거 자료에서 그 종류의 어긋남은 조용히 틀린 값이 된다.
+ * <p>
+ * 별도 빈으로 뽑은 이유: 공휴일 API 라이브 호출({@code HolidayApiClient})은 트랜잭션 <b>밖</b>에
+ * 있어야 하는데, 같은 클래스 안에서 {@code @Transactional} 메서드를 자기호출하면 프록시를
+ * 타지 않아 애초에 트랜잭션이 걸리지 않는다. 경계를 클래스 경계와 일치시킨다.
+ */
+@Component
+public class OverTimeSnapshotReader {
+
+    private final CommuteHistoryRepository commuteHistoryRepository;
+    private final EmployeeRepository employeeRepository;
+
+    public OverTimeSnapshotReader(
+            CommuteHistoryRepository commuteHistoryRepository,
+            EmployeeRepository employeeRepository
+    ) {
+        this.commuteHistoryRepository = commuteHistoryRepository;
+        this.employeeRepository = employeeRepository;
+    }
+
+    @Transactional(readOnly = true)
+    public OverTimeSnapshot read(YearMonth yearMonth) {
+        // 대상 월 1일이 속한 주(월~일)의 월요일부터 조회 — 그 주의 40시간 판정에 전월 말 기록이 필요하다
+        LocalDate rangeStart = MonthlyOverTimeCalculator.requiredRangeStart(yearMonth);
+        LocalDate rangeEnd = yearMonth.atEndOfMonth();
+
+        return new OverTimeSnapshot(
+                // 대상자 판정은 월 경계 기준 — 스필오버 주(전월 말)의 근무는 그 직원의 전월 리포트가 이미 집계했다
+                employeeRepository.findAllWithTeamEmployedBetween(yearMonth.atDay(1), rangeEnd),
+                commuteHistoryRepository.findDailyWorkingMinutesByWorkDateBetween(rangeStart, rangeEnd)
+        );
+    }
+}

--- a/src/main/java/com/company/officecommute/service/overtime/UnclosedCommute.java
+++ b/src/main/java/com/company/officecommute/service/overtime/UnclosedCommute.java
@@ -1,0 +1,14 @@
+package com.company.officecommute.service.overtime;
+
+import java.time.LocalDate;
+
+/**
+ * 퇴근이 찍히지 않은 출근 기록 한 건. 관리자에게 "무엇을 마감해야 하는지" 알려주려면
+ * 건수({@code countUnclosedCommutes})만으로는 부족해 사번·이름·근무일이 필요하다.
+ */
+public record UnclosedCommute(
+        String employeeCode,
+        String employeeName,
+        LocalDate workDate
+) {
+}

--- a/src/main/java/com/company/officecommute/service/report/OverTimeReportDispatchService.java
+++ b/src/main/java/com/company/officecommute/service/report/OverTimeReportDispatchService.java
@@ -1,0 +1,162 @@
+package com.company.officecommute.service.report;
+
+import com.company.officecommute.domain.report.DispatchFailureReason;
+import com.company.officecommute.domain.report.ReportDispatch;
+import com.company.officecommute.dto.overtime.response.OverTimeReport;
+import com.company.officecommute.global.exception.HolidayDataUnavailableException;
+import com.company.officecommute.mail.ReportMailException;
+import com.company.officecommute.mail.ReportMailer;
+import com.company.officecommute.repository.report.ReportDispatchRepository;
+import com.company.officecommute.service.overtime.OverTimeReportService;
+import com.company.officecommute.service.overtime.OverTimeService;
+import com.company.officecommute.service.overtime.UnclosedCommute;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.mail.MailException;
+import org.springframework.stereotype.Service;
+
+import java.io.ByteArrayOutputStream;
+import java.time.Clock;
+import java.time.Duration;
+import java.time.Instant;
+import java.time.YearMonth;
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * 초과근무 리포트 발송의 <b>유일한 진입점</b>. 매월 배치도 관리자의 수동 재실행도 이것을 부른다.
+ * <p>
+ * 멱등성의 근거는 {@code report_dispatch}의 {@code UNIQUE(target_year_month)}다 —
+ * 이미 {@code SENT}인 달은 몇 번을 불러도 아무 일도 일어나지 않으므로 강제 발송 플래그를 두지 않는다.
+ * <p>
+ * 이 클래스는 예외를 밖으로 던지지 않는다. 스케줄러 스레드에서 예외가 올라가면 그 뒤의
+ * 재시도까지 함께 사라진다 — 모든 실패는 이력에 기록되고 분류된다.
+ */
+@Service
+public class OverTimeReportDispatchService {
+
+    private static final Logger log = LoggerFactory.getLogger(OverTimeReportDispatchService.class);
+
+    /**
+     * 선점 리스. 발송 도중 프로세스가 죽으면 {@code IN_PROGRESS}가 남는데, 회수 없이는
+     * 그 달이 영원히 잠긴다. 한 번의 발송(집계 + 엑셀 + SMTP)이 넉넉히 끝나는 시간으로 잡는다.
+     */
+    private static final Duration LEASE = Duration.ofMinutes(30);
+
+    private final ReportDispatchRepository reportDispatchRepository;
+    private final OverTimeReportService overTimeReportService;
+    private final OverTimeService overTimeService;
+    private final ReportMailer reportMailer;
+    private final Clock clock;
+
+    public OverTimeReportDispatchService(
+            ReportDispatchRepository reportDispatchRepository,
+            OverTimeReportService overTimeReportService,
+            OverTimeService overTimeService,
+            ReportMailer reportMailer,
+            Clock clock
+    ) {
+        this.reportDispatchRepository = reportDispatchRepository;
+        this.overTimeReportService = overTimeReportService;
+        this.overTimeService = overTimeService;
+        this.reportMailer = reportMailer;
+        this.clock = clock;
+    }
+
+    public void dispatch(YearMonth target) {
+        ReportDispatch dispatch = claim(target);
+        if (dispatch == null) {
+            return;
+        }
+
+        log.info("초과근무 리포트 발송 시도 시작 — 대상 월 {}, 시도 {}회차", target, dispatch.getAttemptCount() + 1);
+        try {
+            runDispatch(target, dispatch);
+        } catch (HolidayDataUnavailableException e) {
+            // 공휴일 fail-closed. 사람이 할 조치가 없고 재시도가 흡수한다.
+            recordFailure(dispatch, DispatchFailureReason.HOLIDAY_DATA_UNAVAILABLE, e.getMessage());
+        } catch (ReportMailException | MailException e) {
+            recordFailure(dispatch, DispatchFailureReason.MAIL_SEND_FAILED, e.getMessage());
+        } catch (Exception e) {
+            log.error("초과근무 리포트 발송 중 예상하지 못한 오류 — 대상 월 {}", target, e);
+            recordFailure(dispatch, DispatchFailureReason.UNEXPECTED, e.toString());
+        }
+    }
+
+    /**
+     * 이 달을 이 실행이 가져갈 수 있으면 선점한 이력을, 아니면 {@code null}을 준다.
+     * <p>
+     * 선점 경합은 유니크 제약이 판정한다 — 애플리케이션 락을 따로 두지 않는다.
+     */
+    private ReportDispatch claim(YearMonth target) {
+        Instant now = clock.instant();
+        Optional<ReportDispatch> found = reportDispatchRepository.findByTargetYearMonth(target);
+
+        if (found.isEmpty()) {
+            try {
+                return reportDispatchRepository.saveAndFlush(ReportDispatch.claim(target, now));
+            } catch (DataIntegrityViolationException e) {
+                log.info("다른 실행이 이미 선점했다 — 대상 월 {}", target);
+                return null;
+            }
+        }
+
+        ReportDispatch dispatch = found.get();
+        if (dispatch.isSent()) {
+            log.info("이미 발송된 달이라 아무것도 하지 않는다 — 대상 월 {}, 발송 시각 {}", target, dispatch.getSentAt());
+            return null;
+        }
+        if (dispatch.isLeaseHeld(now, LEASE)) {
+            log.info("다른 실행이 진행 중이다 — 대상 월 {}, 마지막 시도 {}", target, dispatch.getLastAttemptedAt());
+            return null;
+        }
+
+        dispatch.beginAttempt(now);
+        return reportDispatchRepository.save(dispatch);
+    }
+
+    /**
+     * 집계·엑셀·발송은 전부 DB 트랜잭션 <b>밖</b>이다. {@code generateReport}가 공휴일 API를
+     * 라이브 호출하므로, 트랜잭션 안에 두면 외부 API 응답 시간만큼 커넥션을 붙잡는다.
+     */
+    private void runDispatch(YearMonth target, ReportDispatch dispatch) throws Exception {
+        OverTimeReport report = overTimeReportService.generateReport(target);
+        byte[] excel = writeExcel(report);
+
+        if (report.hasUnclosedCommutes()) {
+            // 미마감은 그 직원의 초과근무를 과소 집계한다 = 조용히 틀린 급여 근거.
+            // 엑셀 첫 행 경고만으로는 "대표가 경고를 읽었을 것"에 기대게 되므로 발송 자체를 막는다.
+            List<UnclosedCommute> unclosed = overTimeService.findUnclosedCommutes(target);
+            reportMailer.sendUnclosedCommuteWarning(report, excel, unclosed);
+            recordFailure(
+                    dispatch,
+                    DispatchFailureReason.UNCLOSED_COMMUTES,
+                    "미마감 %d건 — 마감되면 다음 재시도에서 자동 발송된다".formatted(report.unclosedCommuteCount())
+            );
+            return;
+        }
+
+        reportMailer.sendMonthlyReport(report, excel);
+        dispatch.markSent(clock.instant());
+        reportDispatchRepository.save(dispatch);
+        log.info("초과근무 리포트 발송 완료 — 대상 월 {}, 대상자 {}명", target, report.rows().size());
+    }
+
+    /**
+     * 엑셀을 <b>다 만든 뒤</b> 첨부한다. 쓰는 도중 실패하면 메일은 시작조차 하지 않으므로
+     * 절반짜리 파일이 대표에게 갈 수 없다.
+     */
+    private byte[] writeExcel(OverTimeReport report) throws Exception {
+        ByteArrayOutputStream buffer = new ByteArrayOutputStream();
+        overTimeReportService.writeExcelReport(report, buffer);
+        return buffer.toByteArray();
+    }
+
+    private void recordFailure(ReportDispatch dispatch, DispatchFailureReason reason, String detail) {
+        log.warn("초과근무 리포트 발송 실패 — 대상 월 {}, 사유 {}, 상세 {}",
+                dispatch.getTargetYearMonth(), reason, detail);
+        dispatch.markFailed(reason.name() + ": " + detail, clock.instant());
+        reportDispatchRepository.save(dispatch);
+    }
+}

--- a/src/main/java/com/company/officecommute/service/report/OverTimeReportDispatchService.java
+++ b/src/main/java/com/company/officecommute/service/report/OverTimeReportDispatchService.java
@@ -3,6 +3,7 @@ package com.company.officecommute.service.report;
 import com.company.officecommute.domain.report.DispatchFailureReason;
 import com.company.officecommute.domain.report.ReportDispatch;
 import com.company.officecommute.dto.overtime.response.OverTimeReport;
+import com.company.officecommute.dto.report.response.OverTimeReportDispatchResponse;
 import com.company.officecommute.global.exception.HolidayDataUnavailableException;
 import com.company.officecommute.mail.ReportMailException;
 import com.company.officecommute.mail.ReportMailer;
@@ -82,6 +83,19 @@ public class OverTimeReportDispatchService {
             log.error("초과근무 리포트 발송 중 예상하지 못한 오류 — 대상 월 {}", target, e);
             recordFailure(dispatch, DispatchFailureReason.UNEXPECTED, e.toString());
         }
+    }
+
+    /**
+     * 수동 재실행. 배치와 <b>완전히 같은</b> {@link #dispatch}를 부르고 현재 상태를 돌려준다.
+     * 강제 발송 플래그는 두지 않는다 — 이미 보낸 달을 한 번 더 보낸다는 요구가 아직 없고,
+     * 생긴다면 그때 별도 유스케이스로 설계한다.
+     */
+    public OverTimeReportDispatchResponse dispatchAndDescribe(YearMonth target) {
+        dispatch(target);
+        return reportDispatchRepository.findByTargetYearMonth(target)
+                .map(OverTimeReportDispatchResponse::from)
+                .orElseThrow(() -> new IllegalStateException(
+                        "발송을 시도했는데 이력이 없다 — 선점 경로가 깨졌다: " + target));
     }
 
     /**

--- a/src/main/java/com/company/officecommute/service/report/OverTimeReportDispatchService.java
+++ b/src/main/java/com/company/officecommute/service/report/OverTimeReportDispatchService.java
@@ -85,6 +85,45 @@ public class OverTimeReportDispatchService {
     }
 
     /**
+     * 재시도 창을 다 쓰고도 발송되지 않은 달을 관리자에게 드러낸다.
+     * "메일이 안 온 것"과 "발송이 실패한 것"이 구분되지 않으면 그것이 조용한 실패다.
+     * <p>
+     * 시도 로직에 "이번이 마지막인가" 조건을 섞지 않기 위해 별도 진입점으로 둔다.
+     */
+    public void alertIfNotSent(YearMonth target) {
+        Optional<ReportDispatch> found = reportDispatchRepository.findByTargetYearMonth(target);
+        if (found.isPresent() && found.get().isSent()) {
+            return;
+        }
+
+        String detail = found
+                .map(d -> "%d회 시도, 마지막 사유: %s".formatted(d.getAttemptCount(), d.getLastFailureReason()))
+                .orElse("발송이 한 번도 시도되지 않았습니다 — 스케줄러 미동작을 의심해야 합니다.");
+        log.error("초과근무 리포트 최종 미발송 — 대상 월 {} ({})", target, detail);
+
+        try {
+            reportMailer.sendDispatchFailure(target, found.map(this::recordedReason).orElse(DispatchFailureReason.UNEXPECTED), detail);
+        } catch (ReportMailException | MailException e) {
+            // 알림 경로 자체가 죽은 경우다. 메일로 알릴 방법이 없으니 로그가 마지막 방어선이다.
+            log.error("최종 미발송 알림 메일마저 실패했다 — 대상 월 {}", target, e);
+        }
+    }
+
+    /** {@code markFailed}가 남긴 "REASON: 상세" 문자열에서 분류를 되읽는다. */
+    private DispatchFailureReason recordedReason(ReportDispatch dispatch) {
+        String recorded = dispatch.getLastFailureReason();
+        if (recorded == null) {
+            return DispatchFailureReason.UNEXPECTED;
+        }
+        for (DispatchFailureReason reason : DispatchFailureReason.values()) {
+            if (recorded.startsWith(reason.name())) {
+                return reason;
+            }
+        }
+        return DispatchFailureReason.UNEXPECTED;
+    }
+
+    /**
      * 이 달을 이 실행이 가져갈 수 있으면 선점한 이력을, 아니면 {@code null}을 준다.
      * <p>
      * 선점 경합은 유니크 제약이 판정한다 — 애플리케이션 락을 따로 두지 않는다.

--- a/src/main/java/com/company/officecommute/web/HolidayApiProperties.java
+++ b/src/main/java/com/company/officecommute/web/HolidayApiProperties.java
@@ -3,6 +3,8 @@ package com.company.officecommute.web;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.context.annotation.Configuration;
 
+import java.time.Duration;
+
 @Configuration
 @ConfigurationProperties(prefix = "public.data.api")
 public class HolidayApiProperties {
@@ -12,6 +14,12 @@ public class HolidayApiProperties {
     // 공공데이터포털이 발급한 "URL 인코딩" 형태의 키를 그대로 보관한다.
     // 디코딩 키를 넣으면 '+'가 서버에서 공백으로 해석되어 인증에 실패한다.
     private String serviceKey;
+
+    // 타임아웃은 이 API 전용 값이므로 키·URL과 같은 prefix 가 소유한다.
+    // 기본값은 코드에 두어 yml 이 값을 주지 않아도 종전 동작(3s/5s)이 유지된다.
+    private Duration connectTimeout = Duration.ofSeconds(3);
+
+    private Duration readTimeout = Duration.ofSeconds(5);
 
     public String getUrl() {
         return url;
@@ -27,6 +35,22 @@ public class HolidayApiProperties {
 
     public void setServiceKey(String serviceKey) {
         this.serviceKey = serviceKey;
+    }
+
+    public Duration getConnectTimeout() {
+        return connectTimeout;
+    }
+
+    public void setConnectTimeout(Duration connectTimeout) {
+        this.connectTimeout = connectTimeout;
+    }
+
+    public Duration getReadTimeout() {
+        return readTimeout;
+    }
+
+    public void setReadTimeout(Duration readTimeout) {
+        this.readTimeout = readTimeout;
     }
 
 }

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -50,3 +50,6 @@ public:
     api:
       serviceKey: ${PUBLIC_API_SERVICE_KEY}
       url: ${PUBLIC_API_URL:https://apis.data.go.kr/B090041/openapi/service/SpcdeInfoService/getRestDeInfo}
+      # 외부 API 타임아웃 — 재배포 없이 조정할 수 있도록 환경변수로 노출 (기본값 = 종전 하드코딩 값)
+      connectTimeout: ${PUBLIC_API_CONNECT_TIMEOUT:3s}
+      readTimeout: ${PUBLIC_API_READ_TIMEOUT:5s}

--- a/src/main/resources/application-mysql.yml
+++ b/src/main/resources/application-mysql.yml
@@ -47,3 +47,6 @@ public:
     api:
       serviceKey: ${PUBLIC_API_SERVICE_KEY}
       url: ${PUBLIC_API_URL:https://apis.data.go.kr/B090041/openapi/service/SpcdeInfoService/getRestDeInfo}
+      # 외부 API 타임아웃 — 재배포 없이 조정할 수 있도록 환경변수로 노출 (기본값 = 종전 하드코딩 값)
+      connectTimeout: ${PUBLIC_API_CONNECT_TIMEOUT:3s}
+      readTimeout: ${PUBLIC_API_READ_TIMEOUT:5s}

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -35,6 +35,28 @@ spring:
       # 배포 전 운영자가 생성한 BCrypt 해시 (V11) — 기본값 없음: 미설정 시 부팅 실패가 정상
       admin_password_hash: ${ADMIN_PASSWORD_HASH}
 
+  # 메일 — 기본값을 두지 않는다. 미설정 시 부팅이 실패하는 편이,
+  # 매월 1일에야 "발송이 안 된다"를 발견하는 것보다 싸다 (ADMIN_PASSWORD_HASH 와 같은 방침).
+  mail:
+    host: ${MAIL_HOST}
+    port: ${MAIL_PORT}
+    username: ${MAIL_USERNAME}
+    password: ${MAIL_PASSWORD}
+    properties:
+      mail:
+        smtp:
+          auth: ${MAIL_SMTP_AUTH:true}
+          starttls:
+            enable: ${MAIL_SMTP_STARTTLS:true}
+
+# 리포트 수신자 (운영 필수)
+report:
+  mail:
+    from: ${REPORT_MAIL_FROM}
+    ceo: ${REPORT_MAIL_CEO}
+    # 복수 지정은 쉼표 구분: a@company.com,b@company.com
+    managers: ${REPORT_MAIL_MANAGERS}
+
 # P6Spy 비활성화 (운영 성능을 위해)
 decorator:
   datasource:

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -65,6 +65,9 @@ public:
     api:
       serviceKey: ${PUBLIC_API_SERVICE_KEY}
       url: ${PUBLIC_API_URL:https://apis.data.go.kr/B090041/openapi/service/SpcdeInfoService/getRestDeInfo}
+      # 외부 API 타임아웃 — 재배포 없이 조정할 수 있도록 환경변수로 노출 (기본값 = 종전 하드코딩 값)
+      connectTimeout: ${PUBLIC_API_CONNECT_TIMEOUT:3s}
+      readTimeout: ${PUBLIC_API_READ_TIMEOUT:5s}
 
 # 서버 포트 설정
 server:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -22,6 +22,22 @@ spring:
   jackson:
     default-property-inclusion: non_null
 
+  # 메일 — 여기 기본값은 dev/test 컨텍스트가 뜨게 하는 용도다.
+  # spring.mail.host 가 없으면 JavaMailSender 빈 자체가 만들어지지 않아 ReportMailer 주입이 깨진다.
+  # 실제 발송이 일어나는 prod 는 application-prod.yml 에서 환경변수로 덮어쓴다(기본값 없음 = 미설정 시 부팅 실패).
+  mail:
+    host: ${MAIL_HOST:localhost}
+    port: ${MAIL_PORT:25}
+    username: ${MAIL_USERNAME:}
+    password: ${MAIL_PASSWORD:}
+
+# 리포트 수신자 — 실값은 prod 환경변수로만 들어온다
+report:
+  mail:
+    from: ${REPORT_MAIL_FROM:}
+    ceo: ${REPORT_MAIL_CEO:}
+    managers: ${REPORT_MAIL_MANAGERS:}
+
 # 서버 공통 설정
 server:
   servlet:

--- a/src/main/resources/db/migration/V13__report_dispatch.sql
+++ b/src/main/resources/db/migration/V13__report_dispatch.sql
@@ -1,0 +1,19 @@
+-- 매월 초과근무 리포트 발송 이력.
+-- UNIQUE(target_year_month) 가 중복 발송 방지의 유일한 하드 보증이다 —
+-- 스케줄 간격·상태 전이는 전부 그 위의 편의 계층이고, 배치 재시도와 수동 재실행이
+-- 겹쳐도 대표는 한 달에 한 통만 받는다.
+--
+-- target_year_month 를 DATE 로 두지 않는 이유: '1일'이라는 존재하지 않는 날짜가
+-- 의미를 갖는 것처럼 보인다. 'yyyy-MM' 문자열이 대상 월이라는 사실을 그대로 표현한다.
+CREATE TABLE report_dispatch
+(
+    report_dispatch_id  BIGINT       NOT NULL AUTO_INCREMENT,
+    target_year_month   CHAR(7)      NOT NULL, -- 'yyyy-MM'
+    status              VARCHAR(20)  NOT NULL, -- IN_PROGRESS | SENT | FAILED
+    attempt_count       INT          NOT NULL,
+    last_attempted_at   DATETIME(6)  NOT NULL,
+    sent_at             DATETIME(6),
+    last_failure_reason VARCHAR(1000),
+    PRIMARY KEY (report_dispatch_id),
+    CONSTRAINT uk_report_dispatch_year_month UNIQUE (target_year_month)
+);

--- a/src/test/docs/adr/2026_08_10_adr3.md
+++ b/src/test/docs/adr/2026_08_10_adr3.md
@@ -1,7 +1,7 @@
 # ADR 3. 매월 1일 초과근무 리포트 자동 발송 — 배치 + 메일 경로 신설
 
 - 날짜: 2026-08-10
-- 상태: 제안 (구현 전) — 관련: TODO.md 4번(본체), 3번 잔여(퇴사자), 6번 일부(타임아웃)
+- 상태: 구현 완료 (2026-08-11, Step 1~7) — 관련: TODO.md 4번(본체), 3번 잔여(퇴사자), 6번 일부(타임아웃)
 - 선행: ADR 1(주 단위 산정)로 리포트 수치 자체는 정합해졌다. 이제 그 수치를 **내보내는** 경로를 만든다.
 
 ## 배경
@@ -26,7 +26,7 @@
 | 미마감 게이트 | `unclosedCommuteCount > 0`이면 **대표 발송 보류**, 근태 관리자에게 교정 요청 | 미마감은 그 직원의 초과근무를 과소 집계한다 = 조용히 틀린 급여 근거 |
 | 최종 실패 | 3일 20:00에 미발송 대상 점검 → 근태 관리자에게 알림 | "메일이 안 온 것"과 "실패한 것"이 구분돼야 한다 |
 | 첨부 방식 | 메모리 버퍼(`ByteArrayResource`)에 **다 쓴 뒤** 첨부 | TODO의 "임시 파일" 지시에서 변경 — 아래 Step 3 참조 |
-| 수동 재실행 | `POST /overtime/report/dispatch` (`@ManagerOnly`), 배치와 **같은 멱등 메서드** | 강제 플래그를 두지 않는다. 이미 SENT면 아무 일도 일어나지 않는다 |
+| 수동 재실행 | `POST /api/overtime/report/dispatch` (`@ManagerOnly`), 배치와 **같은 멱등 메서드** | 강제 플래그를 두지 않는다. 이미 SENT면 아무 일도 일어나지 않는다 |
 
 ---
 
@@ -65,8 +65,8 @@ GreenMail 등 새 테스트 의존성은 도입하지 않는다.
 
 ## Step 2. 발송 이력 — 멱등성의 근거
 
-**마이그레이션 `V12__report_dispatch.sql`** (원문 V11 — Step 0.3 선행 조치인 퇴사자 처리가
-`V11__employee_work_end_date.sql`을 사용해 한 칸 밀림, 2026-08-10)
+**마이그레이션 `V13__report_dispatch.sql`** (원문 V11 — 리베이스로 V11은 admin 비밀번호
+로테이션, V12는 Step 0.3 선행 조치인 `V12__employee_work_end_date.sql`이 차지해 두 칸 밀림, 2026-08-11)
 
 ```sql
 CREATE TABLE report_dispatch (
@@ -200,7 +200,7 @@ public void alertIfNotSent() { ... }  // 전월 이력이 SENT가 아니면 관�
 ## Step 6. 수동 재실행 엔드포인트
 
 ```
-POST /overtime/report/dispatch?yearMonth=2026-07     @ManagerOnly
+POST /api/overtime/report/dispatch?yearMonth=2026-07     @ManagerOnly
 ```
 
 - 배치와 **완전히 같은** `dispatch(YearMonth)`를 호출한다. 강제 발송 플래그는 두지 않는다 —
@@ -248,5 +248,7 @@ POST /overtime/report/dispatch?yearMonth=2026-07     @ManagerOnly
   `Employee.workEndDate` + 재직 겹침 필터. 퇴사자 로그인·출퇴근 차단은 TODO 3에 별도 항목으로 남음
 - 직원별 통상시급(`HOURLY_ORDINARY_WAGE = 15000` 하드코딩) — TODO 5
 - 야간근로(22~06시 +0.5), 휴게시간 미차감 — TODO 5
-- `OverTimeService.calculateOverTime`의 `@Transactional(readOnly = true)` — TODO 6.
-  Step 4에서 "외부 호출을 트랜잭션 밖으로"라는 같은 제약을 이미 다루므로 함께 처리해도 좋다.
+- ~~`OverTimeService.calculateOverTime`의 `@Transactional(readOnly = true)` — TODO 6.~~
+  처리 완료(2026-08-11): 두 DB 조회를 `OverTimeSnapshotReader`(`@Transactional(readOnly = true)`)로
+  묶고 공휴일 라이브 호출은 그 밖에 남겼다. 같은 클래스 안 자기호출은 프록시를 타지 않으므로
+  트랜잭션 경계를 클래스 경계와 일치시켰다.

--- a/src/test/java/com/company/officecommute/controller/overtime/OverTimeControllerTest.java
+++ b/src/test/java/com/company/officecommute/controller/overtime/OverTimeControllerTest.java
@@ -4,9 +4,12 @@ import com.company.officecommute.domain.employee.Role;
 import com.company.officecommute.dto.overtime.response.OverTimeCalculateResponse;
 import com.company.officecommute.dto.overtime.response.OverTimeReport;
 import com.company.officecommute.dto.overtime.response.OverTimeReportData;
+import com.company.officecommute.dto.report.response.OverTimeReportDispatchResponse;
+import com.company.officecommute.domain.report.DispatchStatus;
 import com.company.officecommute.global.exception.HolidayDataUnavailableException;
 import com.company.officecommute.service.overtime.OverTimeReportService;
 import com.company.officecommute.service.overtime.OverTimeService;
+import com.company.officecommute.service.report.OverTimeReportDispatchService;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -22,6 +25,7 @@ import org.springframework.test.web.servlet.assertj.MockMvcTester;
 import java.io.OutputStream;
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
+import java.time.Instant;
 import java.time.YearMonth;
 import java.util.Arrays;
 import java.util.List;
@@ -30,6 +34,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
 import static org.mockito.BDDMockito.willThrow;
 
 @SpringBootTest
@@ -44,6 +49,9 @@ class OverTimeControllerTest {
 
     @MockitoBean
     private OverTimeReportService overTimeReportService;
+
+    @MockitoBean
+    private OverTimeReportDispatchService overTimeReportDispatchService;
 
     @Nested
     @DisplayName("초과근무 조회 API 테스트")
@@ -241,6 +249,69 @@ class OverTimeControllerTest {
                     .session(managerSession()))
                     .failure()
                     .hasRootCauseMessage("엑셀 생성 실패");
+        }
+    }
+
+    @Nested
+    @DisplayName("리포트 수동 발송 API 테스트")
+    class DispatchReportTests {
+
+        @Test
+        @DisplayName("MANAGER가 수동 발송하면 실행 후 현재 발송 상태를 돌려준다")
+        void dispatch_returnsCurrentStatus() {
+            given(overTimeReportDispatchService.dispatchAndDescribe(YearMonth.of(2026, 7)))
+                    .willReturn(new OverTimeReportDispatchResponse(
+                            YearMonth.of(2026, 7), DispatchStatus.SENT, 1,
+                            Instant.parse("2026-08-01T06:00:00Z"), null));
+
+            assertThat(mockMvcTester
+                    .post()
+                    .uri("/api/overtime/report/dispatch?yearMonth=2026-07")
+                    .session(managerSession()))
+                    .hasStatus(HttpStatus.OK)
+                    .bodyJson()
+                    .isLenientlyEqualTo("""
+                            {
+                                "yearMonth": "2026-07",
+                                "status": "SENT",
+                                "attemptCount": 1
+                            }
+                            """);
+        }
+
+        @Test
+        @DisplayName("미마감으로 보류되면 FAILED와 사유가 그대로 노출된다 — 관리자가 즉시 확인할 수 있어야 한다")
+        void dispatch_exposesFailureReason() {
+            given(overTimeReportDispatchService.dispatchAndDescribe(YearMonth.of(2026, 7)))
+                    .willReturn(new OverTimeReportDispatchResponse(
+                            YearMonth.of(2026, 7), DispatchStatus.FAILED, 2, null,
+                            "UNCLOSED_COMMUTES: 미마감 3건"));
+
+            assertThat(mockMvcTester
+                    .post()
+                    .uri("/api/overtime/report/dispatch?yearMonth=2026-07")
+                    .session(managerSession()))
+                    .hasStatus(HttpStatus.OK)
+                    .bodyJson()
+                    .isLenientlyEqualTo("""
+                            {
+                                "status": "FAILED",
+                                "attemptCount": 2,
+                                "lastFailureReason": "UNCLOSED_COMMUTES: 미마감 3건"
+                            }
+                            """);
+        }
+
+        @Test
+        @DisplayName("MEMBER는 수동 발송할 수 없다 — 대표에게 메일을 보내는 경로다")
+        void dispatch_forbiddenForMember() {
+            assertThat(mockMvcTester
+                    .post()
+                    .uri("/api/overtime/report/dispatch?yearMonth=2026-07")
+                    .session(memberSession()))
+                    .hasStatus(HttpStatus.FORBIDDEN);
+
+            then(overTimeReportDispatchService).shouldHaveNoInteractions();
         }
     }
 

--- a/src/test/java/com/company/officecommute/domain/report/ReportDispatchTest.java
+++ b/src/test/java/com/company/officecommute/domain/report/ReportDispatchTest.java
@@ -1,0 +1,88 @@
+package com.company.officecommute.domain.report;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.time.YearMonth;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class ReportDispatchTest {
+
+    private static final YearMonth JULY = YearMonth.of(2026, 7);
+    private static final Instant NOW = Instant.parse("2026-08-01T06:00:00Z");
+    private static final Duration LEASE = Duration.ofMinutes(30);
+
+    @Test
+    @DisplayName("선점 직후는 IN_PROGRESS이고 아직 시도 횟수가 0이다")
+    void claim_startsInProgress() {
+        ReportDispatch dispatch = ReportDispatch.claim(JULY, NOW);
+
+        assertThat(dispatch.getStatus()).isEqualTo(DispatchStatus.IN_PROGRESS);
+        assertThat(dispatch.getAttemptCount()).isZero();
+        assertThat(dispatch.isSent()).isFalse();
+    }
+
+    @Test
+    @DisplayName("발송 성공은 SENT + sentAt을 남기고 이전 실패 사유를 지운다")
+    void markSent_clearsFailureReason() {
+        ReportDispatch dispatch = ReportDispatch.claim(JULY, NOW);
+        dispatch.markFailed("HOLIDAY_DATA_UNAVAILABLE", NOW);
+
+        dispatch.markSent(NOW.plus(Duration.ofHours(4)));
+
+        assertThat(dispatch.isSent()).isTrue();
+        assertThat(dispatch.getSentAt()).isEqualTo(NOW.plus(Duration.ofHours(4)));
+        assertThat(dispatch.getLastFailureReason()).isNull();
+        assertThat(dispatch.getAttemptCount()).isEqualTo(2);
+    }
+
+    @Test
+    @DisplayName("실패는 시도 횟수를 올리고 사유를 남긴다")
+    void markFailed_recordsReason() {
+        ReportDispatch dispatch = ReportDispatch.claim(JULY, NOW);
+
+        dispatch.markFailed("UNCLOSED_COMMUTES: 3건", NOW);
+
+        assertThat(dispatch.getStatus()).isEqualTo(DispatchStatus.FAILED);
+        assertThat(dispatch.getAttemptCount()).isEqualTo(1);
+        assertThat(dispatch.getLastFailureReason()).isEqualTo("UNCLOSED_COMMUTES: 3건");
+    }
+
+    @Test
+    @DisplayName("실패 사유가 컬럼 길이를 넘으면 잘라 저장한다 — 기록하려다 저장이 터지면 본말전도")
+    void markFailed_truncatesLongReason() {
+        ReportDispatch dispatch = ReportDispatch.claim(JULY, NOW);
+
+        dispatch.markFailed("x".repeat(1500), NOW);
+
+        assertThat(dispatch.getLastFailureReason()).hasSize(1000);
+    }
+
+    @Test
+    @DisplayName("리스 시간 안의 IN_PROGRESS는 다른 실행이 잡고 있는 것으로 본다")
+    void isLeaseHeld_withinLease() {
+        ReportDispatch dispatch = ReportDispatch.claim(JULY, NOW);
+
+        assertThat(dispatch.isLeaseHeld(NOW.plus(Duration.ofMinutes(29)), LEASE)).isTrue();
+    }
+
+    @Test
+    @DisplayName("리스 시간이 지난 IN_PROGRESS는 회수 대상 — 그 달이 영원히 잠기면 안 된다")
+    void isLeaseHeld_expired() {
+        ReportDispatch dispatch = ReportDispatch.claim(JULY, NOW);
+
+        assertThat(dispatch.isLeaseHeld(NOW.plus(Duration.ofMinutes(31)), LEASE)).isFalse();
+    }
+
+    @Test
+    @DisplayName("FAILED는 진행 중이 아니므로 리스와 무관하게 다음 시도가 집어간다")
+    void isLeaseHeld_failedIsNotHeld() {
+        ReportDispatch dispatch = ReportDispatch.claim(JULY, NOW);
+        dispatch.markFailed("MAIL_SEND_FAILED", NOW);
+
+        assertThat(dispatch.isLeaseHeld(NOW, LEASE)).isFalse();
+    }
+}

--- a/src/test/java/com/company/officecommute/mail/ReportMailerTest.java
+++ b/src/test/java/com/company/officecommute/mail/ReportMailerTest.java
@@ -1,0 +1,176 @@
+package com.company.officecommute.mail;
+
+import com.company.officecommute.domain.report.DispatchFailureReason;
+import com.company.officecommute.dto.overtime.response.OverTimeReport;
+import com.company.officecommute.dto.overtime.response.OverTimeReportData;
+import com.company.officecommute.service.overtime.UnclosedCommute;
+import jakarta.mail.Message;
+import jakarta.mail.internet.MimeMessage;
+import jakarta.mail.internet.MimeMultipart;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.mail.javamail.JavaMailSender;
+
+import java.time.LocalDate;
+import java.time.YearMonth;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.never;
+
+@ExtendWith(MockitoExtension.class)
+class ReportMailerTest {
+
+    private static final YearMonth JULY = YearMonth.of(2026, 7);
+
+    @Mock
+    private JavaMailSender mailSender;
+
+    private ReportMailProperties properties;
+    private ReportMailer mailer;
+
+    @BeforeEach
+    void setUp() {
+        properties = new ReportMailProperties();
+        properties.setFrom("noreply@company.com");
+        properties.setCeo("ceo@company.com");
+        properties.setManagers(List.of("hr1@company.com", "hr2@company.com"));
+        mailer = new ReportMailer(mailSender, properties);
+    }
+
+    @Test
+    @DisplayName("정상 리포트는 대표에게만 가고, 첨부 파일명·제목에 대상 월이 들어간다")
+    void sendMonthlyReport_toCeoWithNamedAttachment() throws Exception {
+        givenRealMimeMessage();
+
+        mailer.sendMonthlyReport(report(JULY, 2, 0), "xlsx-bytes".getBytes());
+
+        MimeMessage sent = captureSent();
+        assertThat(recipients(sent)).containsExactly("ceo@company.com");
+        assertThat(sent.getSubject()).contains("2026년 7월");
+        assertThat(attachmentFileName(sent)).isEqualTo("2026년7월_초과근무보고서.xlsx");
+    }
+
+    @Test
+    @DisplayName("정상 리포트 본문에 대상자 수·미마감 건수·산정 기준이 들어간다")
+    void sendMonthlyReport_bodyCarriesReliabilitySignals() throws Exception {
+        givenRealMimeMessage();
+
+        mailer.sendMonthlyReport(report(JULY, 2, 0), "xlsx-bytes".getBytes());
+
+        String body = bodyText(captureSent());
+        assertThat(body)
+                .contains("대상 월: 2026년 7월")
+                .contains("대상자: 2명")
+                .contains("퇴근 미마감: 0건")
+                .contains("1일 8시간·1주 40시간 초과, 휴일근로 별도 트랙");
+    }
+
+    @Test
+    @DisplayName("미마감 보류 경고는 관리자 전원에게 가고 본문에 미마감 목록이 들어간다")
+    void sendUnclosedCommuteWarning_toManagersWithList() throws Exception {
+        givenRealMimeMessage();
+
+        mailer.sendUnclosedCommuteWarning(
+                report(JULY, 2, 1),
+                "xlsx-bytes".getBytes(),
+                List.of(new UnclosedCommute("EMP001", "임형준", LocalDate.of(2026, 7, 31)))
+        );
+
+        MimeMessage sent = captureSent();
+        assertThat(recipients(sent)).containsExactly("hr1@company.com", "hr2@company.com");
+        assertThat(sent.getSubject()).contains("2026년 7월").contains("발송 보류");
+        assertThat(bodyText(sent)).contains("EMP001 임형준 2026-07-31");
+        // 관리자가 수치를 바로 확인할 수 있도록 리포트도 함께 간다
+        assertThat(attachmentFileName(sent)).isEqualTo("2026년7월_초과근무보고서.xlsx");
+    }
+
+    @Test
+    @DisplayName("발송 실패 알림은 관리자에게 사유 분류와 조치 안내를 담아 간다")
+    void sendDispatchFailure_toManagersWithReason() throws Exception {
+        givenRealMimeMessage();
+
+        mailer.sendDispatchFailure(JULY, DispatchFailureReason.HOLIDAY_DATA_UNAVAILABLE, "resultCode=22");
+
+        MimeMessage sent = captureSent();
+        assertThat(recipients(sent)).containsExactly("hr1@company.com", "hr2@company.com");
+        assertThat(sent.getSubject()).contains("2026년 7월").contains("HOLIDAY_DATA_UNAVAILABLE");
+        assertThat(bodyText(sent))
+                .contains(DispatchFailureReason.HOLIDAY_DATA_UNAVAILABLE.getManagerGuidance())
+                .contains("resultCode=22");
+    }
+
+    @Test
+    @DisplayName("관리자 주소가 비어 있으면 조용히 넘어가지 않고 설정 누락으로 실패한다")
+    void managersNotConfigured_fails() {
+        properties.setManagers(List.of());
+
+        assertThatThrownBy(() -> mailer.sendDispatchFailure(JULY, DispatchFailureReason.UNEXPECTED, "boom"))
+                .isInstanceOf(ReportMailException.class)
+                .hasMessageContaining("report.mail.managers");
+
+        then(mailSender).should(never()).send(org.mockito.ArgumentMatchers.any(MimeMessage.class));
+    }
+
+    private void givenRealMimeMessage() {
+        // MimeMessageHelper 가 실제로 조립한 결과를 검증해야 하므로 목이 아닌 진짜 MimeMessage 를 준다
+        given(mailSender.createMimeMessage()).willReturn(new MimeMessage((jakarta.mail.Session) null));
+    }
+
+    private MimeMessage captureSent() {
+        ArgumentCaptor<MimeMessage> captor = ArgumentCaptor.forClass(MimeMessage.class);
+        then(mailSender).should().send(captor.capture());
+        return captor.getValue();
+    }
+
+    private List<String> recipients(MimeMessage message) throws Exception {
+        return List.of(message.getRecipients(Message.RecipientType.TO)).stream()
+                .map(Object::toString)
+                .toList();
+    }
+
+    private String attachmentFileName(MimeMessage message) throws Exception {
+        MimeMultipart multipart = (MimeMultipart) message.getContent();
+        for (int i = 0; i < multipart.getCount(); i++) {
+            String fileName = multipart.getBodyPart(i).getFileName();
+            if (fileName != null) {
+                return fileName;
+            }
+        }
+        return null;
+    }
+
+    private String bodyText(MimeMessage message) throws Exception {
+        return readText(message.getContent());
+    }
+
+    private String readText(Object content) throws Exception {
+        if (content instanceof String text) {
+            return text;
+        }
+        MimeMultipart multipart = (MimeMultipart) content;
+        StringBuilder builder = new StringBuilder();
+        for (int i = 0; i < multipart.getCount(); i++) {
+            if (multipart.getBodyPart(i).getFileName() == null) {
+                builder.append(readText(multipart.getBodyPart(i).getContent()));
+            }
+        }
+        return builder.toString();
+    }
+
+    private OverTimeReport report(YearMonth yearMonth, int rowCount, long unclosedCount) {
+        List<OverTimeReportData> rows = java.util.stream.IntStream.range(0, rowCount)
+                .mapToObj(i -> new OverTimeReportData(
+                        "EMP00" + i, "직원" + i, "백엔드팀", 60, 0, 0, 22500))
+                .toList();
+        return new OverTimeReport(yearMonth, rows, unclosedCount);
+    }
+}

--- a/src/test/java/com/company/officecommute/repository/report/ReportDispatchRepositoryMySqlIntegrationTest.java
+++ b/src/test/java/com/company/officecommute/repository/report/ReportDispatchRepositoryMySqlIntegrationTest.java
@@ -1,0 +1,53 @@
+package com.company.officecommute.repository.report;
+
+import com.company.officecommute.domain.report.ReportDispatch;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.testcontainers.containers.MySQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+import java.time.Instant;
+import java.time.YearMonth;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * H2({@code ReportDispatchRepositoryTest})는 엔티티 매핑으로 스키마를 만들기 때문에
+ * "V13 마이그레이션이 엔티티와 어긋났다"를 잡지 못한다. 여기서는 Flyway 로 실제 마이그레이션을
+ * 적용하고 {@code ddl-auto=validate} 로 검증하므로, 컨텍스트가 뜨는 것 자체가 V13 정합 검사다.
+ * <p>
+ * Docker 가 없는 환경에서는 건너뛴다(기존 MySQL 통합 테스트와 같은 조건).
+ */
+@SpringBootTest(properties = {
+        "spring.flyway.enabled=true",
+        "spring.jpa.hibernate.ddl-auto=validate",
+        "spring.jpa.defer-datasource-initialization=false",
+        "spring.sql.init.mode=never"
+})
+@Testcontainers(disabledWithoutDocker = true)
+class ReportDispatchRepositoryMySqlIntegrationTest {
+
+    private static final YearMonth JULY = YearMonth.of(2026, 7);
+    private static final Instant NOW = Instant.parse("2026-08-01T06:00:00Z");
+
+    @Container
+    @ServiceConnection
+    static final MySQLContainer<?> MYSQL = new MySQLContainer<>("mysql:8.4");
+
+    @Autowired
+    private ReportDispatchRepository reportDispatchRepository;
+
+    @Test
+    @DisplayName("V13 의 uk_report_dispatch_year_month 가 같은 달의 두 번째 선점을 막는다")
+    void duplicateYearMonth_rejectedByMigrationConstraint() {
+        reportDispatchRepository.saveAndFlush(ReportDispatch.claim(JULY, NOW));
+
+        assertThatThrownBy(() -> reportDispatchRepository.saveAndFlush(ReportDispatch.claim(JULY, NOW)))
+                .isInstanceOf(DataIntegrityViolationException.class);
+    }
+}

--- a/src/test/java/com/company/officecommute/repository/report/ReportDispatchRepositoryTest.java
+++ b/src/test/java/com/company/officecommute/repository/report/ReportDispatchRepositoryTest.java
@@ -1,0 +1,55 @@
+package com.company.officecommute.repository.report;
+
+import com.company.officecommute.domain.report.ReportDispatch;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.dao.DataIntegrityViolationException;
+
+import java.time.Instant;
+import java.time.YearMonth;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@DataJpaTest
+class ReportDispatchRepositoryTest {
+
+    private static final YearMonth JULY = YearMonth.of(2026, 7);
+    private static final Instant NOW = Instant.parse("2026-08-01T06:00:00Z");
+
+    @Autowired
+    private ReportDispatchRepository reportDispatchRepository;
+
+    @Test
+    @DisplayName("같은 대상 월로 두 번 선점하면 두 번째가 제약 위반으로 실패한다 — 중복 발송 방지의 하드 보증")
+    void duplicateYearMonth_violatesUniqueConstraint() {
+        reportDispatchRepository.saveAndFlush(ReportDispatch.claim(JULY, NOW));
+
+        assertThatThrownBy(() -> reportDispatchRepository.saveAndFlush(ReportDispatch.claim(JULY, NOW)))
+                .isInstanceOf(DataIntegrityViolationException.class);
+    }
+
+    @Test
+    @DisplayName("다른 대상 월은 나란히 존재한다")
+    void differentYearMonth_coexists() {
+        reportDispatchRepository.saveAndFlush(ReportDispatch.claim(JULY, NOW));
+        reportDispatchRepository.saveAndFlush(ReportDispatch.claim(JULY.minusMonths(1), NOW));
+
+        assertThat(reportDispatchRepository.findAll()).hasSize(2);
+    }
+
+    @Test
+    @DisplayName("YearMonth는 'yyyy-MM' 문자열로 저장돼 그대로 되읽힌다")
+    void yearMonthRoundTrips() {
+        reportDispatchRepository.saveAndFlush(ReportDispatch.claim(JULY, NOW));
+        reportDispatchRepository.flush();
+
+        assertThat(reportDispatchRepository.findByTargetYearMonth(JULY))
+                .isPresent()
+                .get()
+                .extracting(ReportDispatch::getTargetYearMonth)
+                .isEqualTo(JULY);
+    }
+}

--- a/src/test/java/com/company/officecommute/scheduler/OverTimeReportDispatchSchedulerTest.java
+++ b/src/test/java/com/company/officecommute/scheduler/OverTimeReportDispatchSchedulerTest.java
@@ -1,0 +1,104 @@
+package com.company.officecommute.scheduler;
+
+import com.company.officecommute.service.report.OverTimeReportDispatchService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.scheduling.support.CronExpression;
+
+import java.time.Clock;
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.YearMonth;
+import java.time.ZoneId;
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.then;
+
+@ExtendWith(MockitoExtension.class)
+class OverTimeReportDispatchSchedulerTest {
+
+    private static final ZoneId KST = ZoneId.of("Asia/Seoul");
+    private static final String DISPATCH_CRON = "0 0 6,10,14,18 1-3 * *";
+    private static final String ALERT_CRON = "0 0 20 3 * *";
+
+    @Mock
+    private OverTimeReportDispatchService dispatchService;
+
+    @Test
+    @DisplayName("발송 cron 의 첫 발화는 1일 06:00 이고 하루 4회다")
+    void dispatchCron_firesFourTimesOnFirstDay() {
+        CronExpression cron = CronExpression.parse(DISPATCH_CRON);
+
+        LocalDateTime first = cron.next(LocalDateTime.of(2026, 8, 31, 23, 59));
+
+        assertThat(first).isEqualTo(LocalDateTime.of(2026, 9, 1, 6, 0));
+        assertThat(cron.next(first)).isEqualTo(LocalDateTime.of(2026, 9, 1, 10, 0));
+        assertThat(cron.next(LocalDateTime.of(2026, 9, 1, 10, 0))).isEqualTo(LocalDateTime.of(2026, 9, 1, 14, 0));
+        assertThat(cron.next(LocalDateTime.of(2026, 9, 1, 14, 0))).isEqualTo(LocalDateTime.of(2026, 9, 1, 18, 0));
+    }
+
+    @Test
+    @DisplayName("발송 cron 은 3일 18:00 이 마지막이고 4일에는 발화하지 않는다 — 재시도 창은 1~3일")
+    void dispatchCron_stopsAfterThirdDay() {
+        CronExpression cron = CronExpression.parse(DISPATCH_CRON);
+
+        LocalDateTime afterLastAttempt = cron.next(LocalDateTime.of(2026, 9, 3, 18, 0));
+
+        // 다음 발화는 4일이 아니라 다음 달 1일이다
+        assertThat(afterLastAttempt).isEqualTo(LocalDateTime.of(2026, 10, 1, 6, 0));
+    }
+
+    @Test
+    @DisplayName("최종 실패 알림 cron 은 마지막 시도 2시간 뒤인 3일 20:00 에 한 번 발화한다")
+    void alertCron_firesOnceOnThirdDayEvening() {
+        CronExpression cron = CronExpression.parse(ALERT_CRON);
+
+        LocalDateTime fire = cron.next(LocalDateTime.of(2026, 9, 1, 0, 0));
+
+        assertThat(fire).isEqualTo(LocalDateTime.of(2026, 9, 3, 20, 0));
+        assertThat(cron.next(fire)).isEqualTo(LocalDateTime.of(2026, 10, 3, 20, 0));
+    }
+
+    @Test
+    @DisplayName("서버 타임존이 UTC여도 1일 06:00 KST 발화는 전월을 가리킨다")
+    void previousMonth_derivedInKstNotServerZone() {
+        // 2026-09-01 06:00 KST == 2026-08-31 21:00 UTC. 서버 TZ 기준으로 파생하면 7월이 되어 한 달 밀린다.
+        OverTimeReportDispatchScheduler scheduler = schedulerAt(
+                ZonedDateTime.of(2026, 9, 1, 6, 0, 0, 0, KST).toInstant(), ZoneOffset.UTC);
+
+        scheduler.dispatchPreviousMonth();
+
+        then(dispatchService).should().dispatch(YearMonth.of(2026, 8));
+    }
+
+    @Test
+    @DisplayName("1월 1일에는 전년 12월을 대상으로 삼는다")
+    void previousMonth_crossesYearBoundary() {
+        OverTimeReportDispatchScheduler scheduler = schedulerAt(
+                ZonedDateTime.of(2026, 1, 1, 6, 0, 0, 0, KST).toInstant(), KST);
+
+        scheduler.dispatchPreviousMonth();
+
+        then(dispatchService).should().dispatch(YearMonth.of(2025, 12));
+    }
+
+    @Test
+    @DisplayName("최종 실패 점검도 같은 대상 월(전월)을 본다 — 3일에 불러도 대상은 바뀌지 않는다")
+    void alert_targetsSamePreviousMonth() {
+        OverTimeReportDispatchScheduler scheduler = schedulerAt(
+                ZonedDateTime.of(2026, 9, 3, 20, 0, 0, 0, KST).toInstant(), ZoneOffset.UTC);
+
+        scheduler.alertIfPreviousMonthNotSent();
+
+        then(dispatchService).should().alertIfNotSent(YearMonth.of(2026, 8));
+    }
+
+    private OverTimeReportDispatchScheduler schedulerAt(Instant instant, ZoneId serverZone) {
+        return new OverTimeReportDispatchScheduler(dispatchService, Clock.fixed(instant, serverZone));
+    }
+}

--- a/src/test/java/com/company/officecommute/service/overtime/OverTimeServiceTest.java
+++ b/src/test/java/com/company/officecommute/service/overtime/OverTimeServiceTest.java
@@ -6,13 +6,14 @@ import com.company.officecommute.domain.employee.Role;
 import com.company.officecommute.domain.team.Team;
 import com.company.officecommute.dto.overtime.response.OverTimeCalculateResponse;
 import com.company.officecommute.repository.commute.CommuteHistoryRepository;
-import com.company.officecommute.repository.employee.EmployeeRepository;
 import com.company.officecommute.web.HolidayApiClient;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InOrder;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
+import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.time.LocalDate;
@@ -42,7 +43,7 @@ class OverTimeServiceTest {
     private CommuteHistoryRepository commuteHistoryRepository;
 
     @Mock
-    private EmployeeRepository employeeRepository;
+    private OverTimeSnapshotReader overTimeSnapshotReader;
 
     @Mock
     private HolidayApiClient holidayApiClient;
@@ -53,12 +54,12 @@ class OverTimeServiceTest {
         Team backend = new Team(1L, "백엔드팀", "팀장", 0);
         Employee recordedEmployee = employee(1L, "임형준", backend, "EMP001", "hyungjun@company.com");
         Employee noHistoryEmployee = employee(2L, "김개발", backend, "EMP002", "dev@company.com");
-        given(employeeRepository.findAllWithTeamEmployedBetween(LocalDate.of(2024, 7, 1), LocalDate.of(2024, 7, 31)))
-                .willReturn(List.of(recordedEmployee, noHistoryEmployee));
         given(holidayApiClient.getHolidays(any(YearMonth.class))).willReturn(Set.of());
         // 7/1(월) 12시간 근무 — 일별 8시간 초과 4시간
-        given(commuteHistoryRepository.findDailyWorkingMinutesByWorkDateBetween(any(LocalDate.class), any(LocalDate.class)))
-                .willReturn(List.of(new DailyWorkingMinutes(1L, LocalDate.of(2024, 7, 1), 720L)));
+        given(overTimeSnapshotReader.read(JULY)).willReturn(new OverTimeSnapshot(
+                List.of(recordedEmployee, noHistoryEmployee),
+                List.of(new DailyWorkingMinutes(1L, LocalDate.of(2024, 7, 1), 720L))
+        ));
 
         List<OverTimeCalculateResponse> responses = overTimeService.calculateOverTime(JULY);
 
@@ -82,11 +83,9 @@ class OverTimeServiceTest {
     @DisplayName("미배정 직원은 근무 기록이 없어도 팀명을 미배정으로 표시한다")
     void calculateOverTime_usesUnassignedTeamNameForEmployeeWithoutTeam() {
         Employee employee = employee(1L, "임형준", null, "EMP001", "hyungjun@company.com");
-        given(employeeRepository.findAllWithTeamEmployedBetween(LocalDate.of(2024, 7, 1), LocalDate.of(2024, 7, 31)))
-                .willReturn(List.of(employee));
         given(holidayApiClient.getHolidays(any(YearMonth.class))).willReturn(Set.of());
-        given(commuteHistoryRepository.findDailyWorkingMinutesByWorkDateBetween(any(LocalDate.class), any(LocalDate.class)))
-                .willReturn(List.of());
+        given(overTimeSnapshotReader.read(JULY))
+                .willReturn(new OverTimeSnapshot(List.of(employee), List.of()));
 
         List<OverTimeCalculateResponse> responses = overTimeService.calculateOverTime(JULY);
 
@@ -96,55 +95,41 @@ class OverTimeServiceTest {
     }
 
     @Test
-    @DisplayName("월 1일이 속한 주가 전월에 걸치면 조회 범위를 그 주의 월요일로 넓히고 전월 공휴일도 함께 가져온다")
-    void calculateOverTime_extendsRangeAndHolidaysToStraddlingWeek() {
-        given(employeeRepository.findAllWithTeamEmployedBetween(any(LocalDate.class), any(LocalDate.class)))
-                .willReturn(List.of());
+    @DisplayName("월 1일이 속한 주가 전월에 걸치면 전월 공휴일도 함께 가져온다")
+    void calculateOverTime_fetchesStraddlingMonthHolidays() {
         given(holidayApiClient.getHolidays(any(YearMonth.class))).willReturn(Set.of());
-        given(commuteHistoryRepository.findDailyWorkingMinutesByWorkDateBetween(any(LocalDate.class), any(LocalDate.class)))
-                .willReturn(List.of());
+        given(overTimeSnapshotReader.read(AUGUST)).willReturn(emptySnapshot());
 
         overTimeService.calculateOverTime(AUGUST);
 
-        // 8/1(목)이 속한 주의 월요일은 7/29 — 그 주의 40시간 판정에 전월 기록·공휴일이 필요하다
-        then(commuteHistoryRepository).should()
-                .findDailyWorkingMinutesByWorkDateBetween(LocalDate.of(2024, 7, 29), LocalDate.of(2024, 8, 31));
+        // 8/1(목)이 속한 주의 월요일은 7/29 — 그 주의 휴일근로 분류에 전월 공휴일이 필요하다
         then(holidayApiClient).should().getHolidays(AUGUST);
         then(holidayApiClient).should().getHolidays(JULY);
     }
 
     @Test
-    @DisplayName("리포트 대상자는 스필오버 주가 아니라 월 경계(1일~말일)의 재직 겹침으로 조회한다")
-    void calculateOverTime_queriesEmployeesByMonthBoundsNotSpilloverStart() {
-        // 7/31 퇴사자는 8월 리포트 대상이 아니다 — 스필오버 주(7/29~)의 근무는 7월 리포트가 이미 집계했다.
-        // 대상자 조회까지 7/29로 넓히면 그 퇴사자가 8월 리포트에 0분 행으로 되살아난다.
-        given(employeeRepository.findAllWithTeamEmployedBetween(any(LocalDate.class), any(LocalDate.class)))
-                .willReturn(List.of());
-        given(holidayApiClient.getHolidays(any(YearMonth.class))).willReturn(Set.of());
-        given(commuteHistoryRepository.findDailyWorkingMinutesByWorkDateBetween(any(LocalDate.class), any(LocalDate.class)))
-                .willReturn(List.of());
-
-        overTimeService.calculateOverTime(AUGUST);
-
-        then(employeeRepository).should()
-                .findAllWithTeamEmployedBetween(LocalDate.of(2024, 8, 1), LocalDate.of(2024, 8, 31));
-    }
-
-    @Test
-    @DisplayName("월 1일이 월요일이면 조회 범위 확장 없이 해당 월 공휴일만 가져온다")
+    @DisplayName("월 1일이 월요일이면 해당 월 공휴일만 가져온다")
     void calculateOverTime_singleMonthHolidaysWhenWeekAlignsWithMonth() {
-        given(employeeRepository.findAllWithTeamEmployedBetween(any(LocalDate.class), any(LocalDate.class)))
-                .willReturn(List.of());
         given(holidayApiClient.getHolidays(any(YearMonth.class))).willReturn(Set.of());
-        given(commuteHistoryRepository.findDailyWorkingMinutesByWorkDateBetween(any(LocalDate.class), any(LocalDate.class)))
-                .willReturn(List.of());
+        given(overTimeSnapshotReader.read(JULY)).willReturn(emptySnapshot());
 
         overTimeService.calculateOverTime(JULY);
 
-        then(commuteHistoryRepository).should()
-                .findDailyWorkingMinutesByWorkDateBetween(LocalDate.of(2024, 7, 1), LocalDate.of(2024, 7, 31));
         then(holidayApiClient).should().getHolidays(JULY);
         then(holidayApiClient).should(never()).getHolidays(YearMonth.of(2024, 6));
+    }
+
+    @Test
+    @DisplayName("공휴일 외부 호출은 DB 읽기 스냅샷보다 먼저 끝난다 — 트랜잭션이 외부 API를 기다리지 않는다")
+    void calculateOverTime_callsHolidayApiBeforeOpeningSnapshot() {
+        given(holidayApiClient.getHolidays(any(YearMonth.class))).willReturn(Set.of());
+        given(overTimeSnapshotReader.read(JULY)).willReturn(emptySnapshot());
+
+        overTimeService.calculateOverTime(JULY);
+
+        InOrder inOrder = Mockito.inOrder(holidayApiClient, overTimeSnapshotReader);
+        inOrder.verify(holidayApiClient).getHolidays(JULY);
+        inOrder.verify(overTimeSnapshotReader).read(JULY);
     }
 
     @Test
@@ -156,27 +141,6 @@ class OverTimeServiceTest {
                 LocalDate.of(2024, 7, 29), LocalDate.of(2024, 8, 31))).willReturn(1L);
 
         assertThat(overTimeService.countUnclosedCommutes(AUGUST)).isEqualTo(1L);
-    }
-
-    @Test
-    @DisplayName("일요일·공휴일 근무는 휴일근로 트랙으로 응답에 실린다")
-    void calculateOverTime_populatesHolidayTracks() {
-        Team backend = new Team(1L, "백엔드팀", "팀장", 0);
-        Employee employee = employee(1L, "임형준", backend, "EMP001", "hyungjun@company.com");
-        given(employeeRepository.findAllWithTeamEmployedBetween(LocalDate.of(2024, 7, 1), LocalDate.of(2024, 7, 31)))
-                .willReturn(List.of(employee));
-        given(holidayApiClient.getHolidays(JULY)).willReturn(Set.of(LocalDate.of(2024, 7, 3)));
-        given(commuteHistoryRepository.findDailyWorkingMinutesByWorkDateBetween(any(LocalDate.class), any(LocalDate.class)))
-                .willReturn(List.of(
-                        new DailyWorkingMinutes(1L, LocalDate.of(2024, 7, 3), 600L), // 공휴일 10h
-                        new DailyWorkingMinutes(1L, LocalDate.of(2024, 7, 7), 360L)  // 일요일 6h
-                ));
-
-        List<OverTimeCalculateResponse> responses = overTimeService.calculateOverTime(JULY);
-
-        assertThat(responses.getFirst().overTimeMinutes()).isZero();
-        assertThat(responses.getFirst().holidayWithin8HoursMinutes()).isEqualTo(840L); // 480 + 360
-        assertThat(responses.getFirst().holidayExceeding8HoursMinutes()).isEqualTo(120L);
     }
 
     @Test
@@ -195,6 +159,31 @@ class OverTimeServiceTest {
         // 두 스텁이 같은 인자로 걸려 있으므로, 범위가 갈라지면 둘 중 하나가 기본값(0/빈 목록)으로 떨어진다
         assertThat(count).isEqualTo(1L);
         assertThat(unclosed).hasSize(1);
+    }
+
+    @Test
+    @DisplayName("일요일·공휴일 근무는 휴일근로 트랙으로 응답에 실린다")
+    void calculateOverTime_populatesHolidayTracks() {
+        Team backend = new Team(1L, "백엔드팀", "팀장", 0);
+        Employee employee = employee(1L, "임형준", backend, "EMP001", "hyungjun@company.com");
+        given(holidayApiClient.getHolidays(JULY)).willReturn(Set.of(LocalDate.of(2024, 7, 3)));
+        given(overTimeSnapshotReader.read(JULY)).willReturn(new OverTimeSnapshot(
+                List.of(employee),
+                List.of(
+                        new DailyWorkingMinutes(1L, LocalDate.of(2024, 7, 3), 600L), // 공휴일 10h
+                        new DailyWorkingMinutes(1L, LocalDate.of(2024, 7, 7), 360L)  // 일요일 6h
+                )
+        ));
+
+        List<OverTimeCalculateResponse> responses = overTimeService.calculateOverTime(JULY);
+
+        assertThat(responses.getFirst().overTimeMinutes()).isZero();
+        assertThat(responses.getFirst().holidayWithin8HoursMinutes()).isEqualTo(840L); // 480 + 360
+        assertThat(responses.getFirst().holidayExceeding8HoursMinutes()).isEqualTo(120L);
+    }
+
+    private OverTimeSnapshot emptySnapshot() {
+        return new OverTimeSnapshot(List.of(), List.of());
     }
 
     private Employee employee(Long id, String name, Team team, String employeeCode, String email) {

--- a/src/test/java/com/company/officecommute/service/overtime/OverTimeServiceTest.java
+++ b/src/test/java/com/company/officecommute/service/overtime/OverTimeServiceTest.java
@@ -179,6 +179,24 @@ class OverTimeServiceTest {
         assertThat(responses.getFirst().holidayExceeding8HoursMinutes()).isEqualTo(120L);
     }
 
+    @Test
+    @DisplayName("미마감 목록 조회 범위는 건수 조회 범위와 정확히 같다 — 어긋나면 '건수 3건, 목록 2건'이 된다")
+    void findUnclosedCommutes_usesSameRangeAsCount() {
+        LocalDate rangeStart = LocalDate.of(2024, 7, 29); // 8/1(목)이 속한 주의 월요일
+        LocalDate rangeEnd = LocalDate.of(2024, 8, 31);
+        given(commuteHistoryRepository.countByWorkDateBetweenAndWorkEndTimeIsNull(rangeStart, rangeEnd))
+                .willReturn(1L);
+        given(commuteHistoryRepository.findUnclosedByWorkDateBetween(rangeStart, rangeEnd))
+                .willReturn(List.of(new UnclosedCommute("EMP001", "임형준", LocalDate.of(2024, 8, 31))));
+
+        long count = overTimeService.countUnclosedCommutes(AUGUST);
+        List<UnclosedCommute> unclosed = overTimeService.findUnclosedCommutes(AUGUST);
+
+        // 두 스텁이 같은 인자로 걸려 있으므로, 범위가 갈라지면 둘 중 하나가 기본값(0/빈 목록)으로 떨어진다
+        assertThat(count).isEqualTo(1L);
+        assertThat(unclosed).hasSize(1);
+    }
+
     private Employee employee(Long id, String name, Team team, String employeeCode, String email) {
         return new EmployeeBuilder()
                 .withId(id)

--- a/src/test/java/com/company/officecommute/service/overtime/OverTimeSnapshotReaderTest.java
+++ b/src/test/java/com/company/officecommute/service/overtime/OverTimeSnapshotReaderTest.java
@@ -1,0 +1,78 @@
+package com.company.officecommute.service.overtime;
+
+import com.company.officecommute.repository.commute.CommuteHistoryRepository;
+import com.company.officecommute.repository.employee.EmployeeRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.time.YearMonth;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.then;
+
+@ExtendWith(MockitoExtension.class)
+class OverTimeSnapshotReaderTest {
+
+    // 2024-08-01은 목요일 — 1일이 속한 주가 7월에 걸친다
+    private static final YearMonth AUGUST = YearMonth.of(2024, 8);
+    // 2024-07-01은 월요일 — 주 경계와 월 경계가 일치한다
+    private static final YearMonth JULY = YearMonth.of(2024, 7);
+
+    @InjectMocks
+    private OverTimeSnapshotReader overTimeSnapshotReader;
+
+    @Mock
+    private CommuteHistoryRepository commuteHistoryRepository;
+
+    @Mock
+    private EmployeeRepository employeeRepository;
+
+    @Test
+    @DisplayName("월 1일이 속한 주가 전월에 걸치면 근무 기록 조회를 그 주의 월요일까지 넓힌다")
+    void read_extendsCommuteRangeToStraddlingWeek() {
+        overTimeSnapshotReader.read(AUGUST);
+
+        // 8/1(목)이 속한 주의 월요일은 7/29 — 그 주의 40시간 판정에 전월 기록이 필요하다
+        then(commuteHistoryRepository).should()
+                .findDailyWorkingMinutesByWorkDateBetween(LocalDate.of(2024, 7, 29), LocalDate.of(2024, 8, 31));
+    }
+
+    @Test
+    @DisplayName("리포트 대상자는 스필오버 주가 아니라 월 경계(1일~말일)의 재직 겹침으로 조회한다")
+    void read_queriesEmployeesByMonthBoundsNotSpilloverStart() {
+        // 7/31 퇴사자는 8월 리포트 대상이 아니다 — 스필오버 주(7/29~)의 근무는 7월 리포트가 이미 집계했다.
+        // 대상자 조회까지 7/29로 넓히면 그 퇴사자가 8월 리포트에 0분 행으로 되살아난다.
+        overTimeSnapshotReader.read(AUGUST);
+
+        then(employeeRepository).should()
+                .findAllWithTeamEmployedBetween(LocalDate.of(2024, 8, 1), LocalDate.of(2024, 8, 31));
+    }
+
+    @Test
+    @DisplayName("스냅샷 조회는 읽기 전용 트랜잭션이다 — 두 쿼리 사이의 비일관 스냅샷을 막는 유일한 근거다")
+    void read_isReadOnlyTransactional() throws NoSuchMethodException {
+        Transactional transactional = OverTimeSnapshotReader.class
+                .getMethod("read", YearMonth.class)
+                .getAnnotation(Transactional.class);
+
+        assertThat(transactional).isNotNull();
+        assertThat(transactional.readOnly()).isTrue();
+    }
+
+    @Test
+    @DisplayName("월 1일이 월요일이면 범위 확장 없이 그 달만 조회한다")
+    void read_singleMonthWhenWeekAlignsWithMonth() {
+        overTimeSnapshotReader.read(JULY);
+
+        then(commuteHistoryRepository).should()
+                .findDailyWorkingMinutesByWorkDateBetween(LocalDate.of(2024, 7, 1), LocalDate.of(2024, 7, 31));
+        then(employeeRepository).should()
+                .findAllWithTeamEmployedBetween(LocalDate.of(2024, 7, 1), LocalDate.of(2024, 7, 31));
+    }
+}

--- a/src/test/java/com/company/officecommute/service/report/OverTimeReportDispatchServiceTest.java
+++ b/src/test/java/com/company/officecommute/service/report/OverTimeReportDispatchServiceTest.java
@@ -176,6 +176,44 @@ class OverTimeReportDispatchServiceTest {
         then(reportMailer).should(times(1)).sendMonthlyReport(any(), any());
     }
 
+    @Test
+    @DisplayName("최종 점검에서 이미 발송된 달은 조용히 넘어간다")
+    void alertIfNotSent_silentWhenSent() {
+        ReportDispatch sent = ReportDispatch.claim(JULY, NOW);
+        sent.markSent(NOW);
+        given(reportDispatchRepository.findByTargetYearMonth(JULY)).willReturn(Optional.of(sent));
+
+        dispatchService.alertIfNotSent(JULY);
+
+        then(reportMailer).shouldHaveNoInteractions();
+    }
+
+    @Test
+    @DisplayName("최종 점검에서 미발송이면 기록된 사유 분류로 관리자에게 알린다")
+    void alertIfNotSent_reportsRecordedReason() {
+        ReportDispatch failed = ReportDispatch.claim(JULY, NOW);
+        failed.markFailed(DispatchFailureReason.UNCLOSED_COMMUTES.name() + ": 미마감 3건", NOW);
+        given(reportDispatchRepository.findByTargetYearMonth(JULY)).willReturn(Optional.of(failed));
+
+        dispatchService.alertIfNotSent(JULY);
+
+        then(reportMailer).should().sendDispatchFailure(
+                eq(JULY), eq(DispatchFailureReason.UNCLOSED_COMMUTES), any());
+    }
+
+    @Test
+    @DisplayName("이력 자체가 없으면 스케줄러 미동작으로 보고 알린다 — 가장 조용한 실패다")
+    void alertIfNotSent_noHistoryAtAll() {
+        given(reportDispatchRepository.findByTargetYearMonth(JULY)).willReturn(Optional.empty());
+
+        dispatchService.alertIfNotSent(JULY);
+
+        ArgumentCaptor<String> detail = ArgumentCaptor.forClass(String.class);
+        then(reportMailer).should().sendDispatchFailure(
+                eq(JULY), eq(DispatchFailureReason.UNEXPECTED), detail.capture());
+        assertThat(detail.getValue()).contains("스케줄러");
+    }
+
     private void givenNoPriorDispatch() {
         given(reportDispatchRepository.findByTargetYearMonth(JULY)).willReturn(Optional.empty());
         given(reportDispatchRepository.saveAndFlush(any())).willAnswer(invocation -> invocation.getArgument(0));

--- a/src/test/java/com/company/officecommute/service/report/OverTimeReportDispatchServiceTest.java
+++ b/src/test/java/com/company/officecommute/service/report/OverTimeReportDispatchServiceTest.java
@@ -1,0 +1,197 @@
+package com.company.officecommute.service.report;
+
+import com.company.officecommute.domain.report.DispatchFailureReason;
+import com.company.officecommute.domain.report.DispatchStatus;
+import com.company.officecommute.domain.report.ReportDispatch;
+import com.company.officecommute.dto.overtime.response.OverTimeReport;
+import com.company.officecommute.dto.overtime.response.OverTimeReportData;
+import com.company.officecommute.global.exception.HolidayDataUnavailableException;
+import com.company.officecommute.mail.ReportMailer;
+import com.company.officecommute.repository.report.ReportDispatchRepository;
+import com.company.officecommute.service.overtime.OverTimeReportService;
+import com.company.officecommute.service.overtime.OverTimeService;
+import com.company.officecommute.service.overtime.UnclosedCommute;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.mail.MailSendException;
+
+import java.time.Clock;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.YearMonth;
+import java.time.ZoneOffset;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.BDDMockito.willThrow;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+
+@ExtendWith(MockitoExtension.class)
+class OverTimeReportDispatchServiceTest {
+
+    private static final YearMonth JULY = YearMonth.of(2026, 7);
+    private static final Instant NOW = Instant.parse("2026-08-01T06:00:00Z");
+
+    @Mock
+    private ReportDispatchRepository reportDispatchRepository;
+
+    @Mock
+    private OverTimeReportService overTimeReportService;
+
+    @Mock
+    private OverTimeService overTimeService;
+
+    @Mock
+    private ReportMailer reportMailer;
+
+    private OverTimeReportDispatchService dispatchService;
+
+    @BeforeEach
+    void setUp() {
+        dispatchService = new OverTimeReportDispatchService(
+                reportDispatchRepository,
+                overTimeReportService,
+                overTimeService,
+                reportMailer,
+                Clock.fixed(NOW, ZoneOffset.UTC)
+        );
+    }
+
+    @Test
+    @DisplayName("이미 발송된 달은 메일러를 한 번도 부르지 않는다 — 멱등의 본체")
+    void alreadySent_doesNothing() {
+        ReportDispatch sent = ReportDispatch.claim(JULY, NOW);
+        sent.markSent(NOW);
+        given(reportDispatchRepository.findByTargetYearMonth(JULY)).willReturn(Optional.of(sent));
+
+        dispatchService.dispatch(JULY);
+
+        then(reportMailer).shouldHaveNoInteractions();
+        then(overTimeReportService).shouldHaveNoInteractions();
+    }
+
+    @Test
+    @DisplayName("다른 실행이 리스를 잡고 있으면 중복으로 집계하지 않는다")
+    void leaseHeldByAnotherRun_doesNothing() {
+        ReportDispatch inProgress = ReportDispatch.claim(JULY, NOW);
+        given(reportDispatchRepository.findByTargetYearMonth(JULY)).willReturn(Optional.of(inProgress));
+
+        dispatchService.dispatch(JULY);
+
+        then(reportMailer).shouldHaveNoInteractions();
+    }
+
+    @Test
+    @DisplayName("리스가 만료된 IN_PROGRESS는 회수해 다시 시도한다 — 그 달이 영원히 잠기면 안 된다")
+    void expiredLease_isReclaimed() {
+        ReportDispatch stale = ReportDispatch.claim(JULY, NOW.minusSeconds(3600));
+        given(reportDispatchRepository.findByTargetYearMonth(JULY)).willReturn(Optional.of(stale));
+        given(reportDispatchRepository.save(any())).willAnswer(invocation -> invocation.getArgument(0));
+        given(overTimeReportService.generateReport(JULY)).willReturn(report(2, 0));
+
+        dispatchService.dispatch(JULY);
+
+        then(reportMailer).should().sendMonthlyReport(any(), any());
+    }
+
+    @Test
+    @DisplayName("미마감이 있으면 대표에게 가지 않고 관리자 경고만 나가며 FAILED(UNCLOSED_COMMUTES)로 남는다")
+    void unclosedCommutes_gatesCeoMail() {
+        givenNoPriorDispatch();
+        given(overTimeReportService.generateReport(JULY)).willReturn(report(2, 3));
+        List<UnclosedCommute> unclosed = List.of(
+                new UnclosedCommute("EMP001", "임형준", LocalDate.of(2026, 7, 31))
+        );
+        given(overTimeService.findUnclosedCommutes(JULY)).willReturn(unclosed);
+
+        dispatchService.dispatch(JULY);
+
+        then(reportMailer).should(never()).sendMonthlyReport(any(), any());
+        then(reportMailer).should().sendUnclosedCommuteWarning(any(), any(), eq(unclosed));
+
+        ReportDispatch recorded = capturedSave();
+        assertThat(recorded.getStatus()).isEqualTo(DispatchStatus.FAILED);
+        assertThat(recorded.getLastFailureReason())
+                .startsWith(DispatchFailureReason.UNCLOSED_COMMUTES.name());
+    }
+
+    @Test
+    @DisplayName("공휴일 API 이용 불가는 대표 미발송 + FAILED로 남고, 예외를 밖으로 던지지 않는다")
+    void holidayDataUnavailable_recordedNotThrown() {
+        givenNoPriorDispatch();
+        given(overTimeReportService.generateReport(JULY))
+                .willThrow(new HolidayDataUnavailableException("resultCode=22"));
+
+        assertThatCode(() -> dispatchService.dispatch(JULY)).doesNotThrowAnyException();
+
+        then(reportMailer).should(never()).sendMonthlyReport(any(), any());
+        ReportDispatch recorded = capturedSave();
+        assertThat(recorded.getStatus()).isEqualTo(DispatchStatus.FAILED);
+        assertThat(recorded.getLastFailureReason())
+                .startsWith(DispatchFailureReason.HOLIDAY_DATA_UNAVAILABLE.name());
+    }
+
+    @Test
+    @DisplayName("SMTP 오류는 MAIL_SEND_FAILED로 분류되고 스케줄러 스레드를 죽이지 않는다")
+    void mailFailure_classifiedAndSwallowed() {
+        givenNoPriorDispatch();
+        given(overTimeReportService.generateReport(JULY)).willReturn(report(2, 0));
+        willThrow(new MailSendException("smtp down")).given(reportMailer).sendMonthlyReport(any(), any());
+
+        assertThatCode(() -> dispatchService.dispatch(JULY)).doesNotThrowAnyException();
+
+        ReportDispatch recorded = capturedSave();
+        assertThat(recorded.getStatus()).isEqualTo(DispatchStatus.FAILED);
+        assertThat(recorded.getLastFailureReason())
+                .startsWith(DispatchFailureReason.MAIL_SEND_FAILED.name());
+    }
+
+    @Test
+    @DisplayName("성공하면 SENT + sentAt이 남고, 이어지는 두 번째 발송은 아무 일도 하지 않는다")
+    void success_thenSecondDispatchIsNoop() {
+        givenNoPriorDispatch();
+        given(overTimeReportService.generateReport(JULY)).willReturn(report(2, 0));
+
+        dispatchService.dispatch(JULY);
+
+        ReportDispatch sent = capturedSave();
+        assertThat(sent.isSent()).isTrue();
+        assertThat(sent.getSentAt()).isEqualTo(NOW);
+
+        given(reportDispatchRepository.findByTargetYearMonth(JULY)).willReturn(Optional.of(sent));
+        dispatchService.dispatch(JULY);
+
+        then(reportMailer).should(times(1)).sendMonthlyReport(any(), any());
+    }
+
+    private void givenNoPriorDispatch() {
+        given(reportDispatchRepository.findByTargetYearMonth(JULY)).willReturn(Optional.empty());
+        given(reportDispatchRepository.saveAndFlush(any())).willAnswer(invocation -> invocation.getArgument(0));
+    }
+
+    /** 결과 기록은 markSent/markFailed 뒤의 save 로 남는다. */
+    private ReportDispatch capturedSave() {
+        ArgumentCaptor<ReportDispatch> captor = ArgumentCaptor.forClass(ReportDispatch.class);
+        then(reportDispatchRepository).should().save(captor.capture());
+        return captor.getValue();
+    }
+
+    private OverTimeReport report(int rowCount, long unclosedCount) {
+        List<OverTimeReportData> rows = java.util.stream.IntStream.range(0, rowCount)
+                .mapToObj(i -> new OverTimeReportData("EMP00" + i, "직원" + i, "백엔드팀", 60, 0, 0, 22500))
+                .toList();
+        return new OverTimeReport(JULY, rows, unclosedCount);
+    }
+}

--- a/src/test/java/com/company/officecommute/web/HolidayApiClientWireTest.java
+++ b/src/test/java/com/company/officecommute/web/HolidayApiClientWireTest.java
@@ -59,12 +59,13 @@ class HolidayApiClientWireTest {
 
     @BeforeEach
     void setUp() {
-        restTemplate = new RestTemplateConfig().restTemplate();
-        server = MockRestServiceServer.bindTo(restTemplate).build();
-
         HolidayApiProperties properties = new HolidayApiProperties();
         properties.setUrl("https://fake-api.com/getRestDeInfo");
         properties.setServiceKey("service%2Bkey");
+
+        restTemplate = new RestTemplateConfig(properties).restTemplate();
+        server = MockRestServiceServer.bindTo(restTemplate).build();
+
         client = new HolidayApiClient(restTemplate, properties);
     }
 

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -1,6 +1,12 @@
 spring:
   profiles:
     active: test
+  # 이 파일이 메인 application.yml 을 가리므로 메일 설정도 여기 있어야 한다.
+  # spring.mail.host 가 없으면 JavaMailSender 빈이 만들어지지 않아 ReportMailer 주입이 깨진다.
+  # 테스트에서 실제로 발송하는 경로는 없다(수신자 주소는 일부러 비워 둔다).
+  mail:
+    host: localhost
+    port: 25
   flyway:
     enabled: false
     placeholders:


### PR DESCRIPTION
## Summary
Implements the complete monthly overtime report dispatch pipeline, including batch scheduling, email delivery with failure handling, and idempotent retry logic. This is the first scheduler and mail integration in the project.

## Key Changes

### Core Dispatch Service
- **`OverTimeReportDispatchService`**: Single entry point for all report dispatch (batch and manual). Implements idempotent dispatch via `UNIQUE(target_year_month)` constraint, preventing duplicate sends even when batch and manual execution overlap.
- Handles three failure modes with distinct recovery paths:
  - Unclosed commutes: blocks CEO email, alerts managers, auto-recovers on next retry
  - Holiday API unavailable: fail-closed, transparent retry
  - Mail/unexpected errors: recorded with details for admin investigation
- Lease-based concurrency: 30-minute lease prevents permanent locking if process dies mid-dispatch

### Batch Scheduler
- **`OverTimeReportDispatchScheduler`**: Fires 4 times daily (06:00, 10:00, 14:00, 18:00 KST) on days 1-3 of each month, providing retry window without manual intervention
- `@Profile("prod")` ensures scheduler only runs in production; dev/test contexts have no mail-sending paths
- Clock injection with explicit KST timezone prevents server timezone drift

### Email Infrastructure
- **`ReportMailer`**: Purpose-specific methods (not flag-based) for three mail types:
  - `sendMonthlyReport()`: CEO only, normal reports
  - `sendUnclosedCommuteWarning()`: Managers, blocks CEO send, includes correctable list
  - `sendDispatchFailure()`: Managers, final failure alerts after retry exhaustion
- **`ReportMailProperties`**: Externalized configuration (from, ceo, managers) prevents hardcoded addresses and enables runtime changes without redeployment

### Domain Model
- **`ReportDispatch`**: Entity with state machine (IN_PROGRESS → SENT/FAILED), owns all state transitions to prevent silent status mutations
- **`DispatchStatus`**: Three states with clear semantics (IN_PROGRESS, SENT, FAILED)
- **`DispatchFailureReason`**: Enum with manager guidance text for each failure type, enabling informed retry decisions
- **`YearMonthAttributeConverter`**: JPA converter for `YearMonth` ↔ `CHAR(7)` 'yyyy-MM' persistence

### Data Access & Snapshot Consistency
- **`OverTimeSnapshotReader`**: Wraps employee + commute queries in single `@Transactional` read to prevent inconsistent snapshots between two queries (critical for payroll accuracy)
- Extracted from `OverTimeService` to enforce transactional boundary; separate bean prevents Spring proxy self-call issue
- **`ReportDispatchRepository`**: Simple JPA repo; uniqueness constraint is the sole hard guarantee against duplicate sends

### API & Manual Dispatch
- **`POST /api/overtime/report/dispatch`**: Manager-only endpoint for immediate dispatch, returns current status (SENT/FAILED with reason)
- Calls identical `dispatch()` logic as batch; no force-send flag (future requirement if needed)
- **`OverTimeReportDispatchResponse`**: DTO exposing status, attempt count, timestamps for admin visibility

### Database
- **V13 migration**: `report_dispatch` table with `UNIQUE(target_year_month)`, `status`, `attemptCount`, `lastAttemptedAt`, `sentAt`, `lastFailureReason`
- Stores full failure history; no "force resend" column (idempotency via status check)

## Notable Implementation Details

1. **No exceptions escape to scheduler**: All failures caught, classified, and recorded. Scheduler thread never dies mid-month.

2. **Idempotency via constraint**: `UNIQUE(target_year_month)` is the sole hard guarantee. Status checks and lease logic are convenience layers; the constraint is the safety net.

3. **Transactional snapshot**: `OverTimeSnapshotReader` ensures employee list and commute records come from same moment, preventing payroll discrepancies.

4. **Timezone-aware scheduling

https://claude.ai/code/session_01RNw4fkDjtJBRJXWx9dc5p1