### PR TITLE
refactor(config): 외부 API 타임아웃을 yml/환경변수 설정으로 분리

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -12,6 +12,9 @@ DB_PASSWORD=office_password
 # 공공 API 설정 (실제 API 테스트시 필요)
 PUBLIC_API_SERVICE_KEY=your-actual-api-service-key-here
 PUBLIC_API_URL=https://apis.data.go.kr/B090041/openapi/service/SpcdeInfoService/getRestDeInfo
+# 외부 API 타임아웃 (선택, 기본 3s/5s — 재배포 없이 조정하려면 여기서 덮어쓴다)
+PUBLIC_API_CONNECT_TIMEOUT=3s
+PUBLIC_API_READ_TIMEOUT=5s
 
 # 서버 포트 (선택사항)
 SERVER_PORT=8080

--- a/src/main/java/com/company/officecommute/config/RestTemplateConfig.java
+++ b/src/main/java/com/company/officecommute/config/RestTemplateConfig.java
@@ -1,5 +1,6 @@
 package com.company.officecommute.config;
 
+import com.company.officecommute.web.HolidayApiProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.client.SimpleClientHttpRequestFactory;
@@ -10,18 +11,25 @@ import org.springframework.web.client.RestTemplate;
 import java.util.ArrayList;
 import java.util.List;
 
+/**
+ * 유일한 소비자는 {@code HolidayApiClient} 다. 따라서 타임아웃도 그 API 의 설정
+ * ({@code public.data.api.*}) 에서 읽는다 — 값이 yml/환경변수로 나와 있어 운영에서
+ * 재배포 없이 조정할 수 있다.
+ */
 @Configuration
 public class RestTemplateConfig {
 
-    // TODO: 운영에서는 외부 API 타임아웃 값을 application-*.yml 설정으로 분리해 배포 없이 조정할 수 있게 한다.
-    private static final int CONNECT_TIMEOUT_MS = 3000;
-    private static final int READ_TIMEOUT_MS = 5000;
+    private final HolidayApiProperties holidayApiProperties;
+
+    public RestTemplateConfig(HolidayApiProperties holidayApiProperties) {
+        this.holidayApiProperties = holidayApiProperties;
+    }
 
     @Bean
     public RestTemplate restTemplate() {
         SimpleClientHttpRequestFactory factory = new SimpleClientHttpRequestFactory();
-        factory.setConnectTimeout(CONNECT_TIMEOUT_MS);
-        factory.setReadTimeout(READ_TIMEOUT_MS);
+        factory.setConnectTimeout(holidayApiProperties.getConnectTimeout());
+        factory.setReadTimeout(holidayApiProperties.getReadTimeout());
 
         RestTemplate restTemplate = new RestTemplate(factory);
 

--- a/src/main/java/com/company/officecommute/web/HolidayApiProperties.java
+++ b/src/main/java/com/company/officecommute/web/HolidayApiProperties.java
@@ -3,6 +3,8 @@ package com.company.officecommute.web;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.context.annotation.Configuration;
 
+import java.time.Duration;
+
 @Configuration
 @ConfigurationProperties(prefix = "public.data.api")
 public class HolidayApiProperties {
@@ -12,6 +14,12 @@ public class HolidayApiProperties {
     // 공공데이터포털이 발급한 "URL 인코딩" 형태의 키를 그대로 보관한다.
     // 디코딩 키를 넣으면 '+'가 서버에서 공백으로 해석되어 인증에 실패한다.
     private String serviceKey;
+
+    // 타임아웃은 이 API 전용 값이므로 키·URL과 같은 prefix 가 소유한다.
+    // 기본값은 코드에 두어 yml 이 값을 주지 않아도 종전 동작(3s/5s)이 유지된다.
+    private Duration connectTimeout = Duration.ofSeconds(3);
+
+    private Duration readTimeout = Duration.ofSeconds(5);
 
     public String getUrl() {
         return url;
@@ -27,6 +35,22 @@ public class HolidayApiProperties {
 
     public void setServiceKey(String serviceKey) {
         this.serviceKey = serviceKey;
+    }
+
+    public Duration getConnectTimeout() {
+        return connectTimeout;
+    }
+
+    public void setConnectTimeout(Duration connectTimeout) {
+        this.connectTimeout = connectTimeout;
+    }
+
+    public Duration getReadTimeout() {
+        return readTimeout;
+    }
+
+    public void setReadTimeout(Duration readTimeout) {
+        this.readTimeout = readTimeout;
     }
 
 }

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -50,3 +50,6 @@ public:
     api:
       serviceKey: ${PUBLIC_API_SERVICE_KEY}
       url: ${PUBLIC_API_URL:https://apis.data.go.kr/B090041/openapi/service/SpcdeInfoService/getRestDeInfo}
+      # 외부 API 타임아웃 — 재배포 없이 조정할 수 있도록 환경변수로 노출 (기본값 = 종전 하드코딩 값)
+      connectTimeout: ${PUBLIC_API_CONNECT_TIMEOUT:3s}
+      readTimeout: ${PUBLIC_API_READ_TIMEOUT:5s}

--- a/src/main/resources/application-mysql.yml
+++ b/src/main/resources/application-mysql.yml
@@ -47,3 +47,6 @@ public:
     api:
       serviceKey: ${PUBLIC_API_SERVICE_KEY}
       url: ${PUBLIC_API_URL:https://apis.data.go.kr/B090041/openapi/service/SpcdeInfoService/getRestDeInfo}
+      # 외부 API 타임아웃 — 재배포 없이 조정할 수 있도록 환경변수로 노출 (기본값 = 종전 하드코딩 값)
+      connectTimeout: ${PUBLIC_API_CONNECT_TIMEOUT:3s}
+      readTimeout: ${PUBLIC_API_READ_TIMEOUT:5s}

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -65,6 +65,9 @@ public:
     api:
       serviceKey: ${PUBLIC_API_SERVICE_KEY}
       url: ${PUBLIC_API_URL:https://apis.data.go.kr/B090041/openapi/service/SpcdeInfoService/getRestDeInfo}
+      # 외부 API 타임아웃 — 재배포 없이 조정할 수 있도록 환경변수로 노출 (기본값 = 종전 하드코딩 값)
+      connectTimeout: ${PUBLIC_API_CONNECT_TIMEOUT:3s}
+      readTimeout: ${PUBLIC_API_READ_TIMEOUT:5s}
 
 # 서버 포트 설정
 server:

--- a/src/test/java/com/company/officecommute/web/HolidayApiClientWireTest.java
+++ b/src/test/java/com/company/officecommute/web/HolidayApiClientWireTest.java
@@ -59,12 +59,13 @@ class HolidayApiClientWireTest {
 
     @BeforeEach
     void setUp() {
-        restTemplate = new RestTemplateConfig().restTemplate();
-        server = MockRestServiceServer.bindTo(restTemplate).build();
-
         HolidayApiProperties properties = new HolidayApiProperties();
         properties.setUrl("https://fake-api.com/getRestDeInfo");
         properties.setServiceKey("service%2Bkey");
+
+        restTemplate = new RestTemplateConfig(properties).restTemplate();
+        server = MockRestServiceServer.bindTo(restTemplate).build();
+
         client = new HolidayApiClient(restTemplate, properties);
     }
 


### PR DESCRIPTION
ADR 3 분할 PR **1/7**. base: `main`

TODO 6 항목. `RestTemplateConfig`에 하드코딩돼 있던 connect/read 타임아웃을 설정으로 뺀다.

## 변경

- 타임아웃 소유권을 `public.data.api` prefix(`HolidayApiProperties`)로 옮기고 세 프로파일 yml에 노출
- `PUBLIC_API_CONNECT_TIMEOUT` / `PUBLIC_API_READ_TIMEOUT`으로 재배포 없이 조정 가능
- 기본값(3s/5s)은 코드에 남겨 yml이 값을 주지 않아도 종전 동작 유지

`RestTemplate`의 유일한 소비자가 `HolidayApiClient`라 같은 prefix가 타임아웃을 갖게 했다. 배치가 공휴일 API에 매달리면 재시도 창을 통째로 잡아먹는데, 온디맨드 조회와 달리 사람이 보고 있지 않다.

## 리뷰 포인트

기존 동작이 바뀌지 않는지. 53줄이고 동작 변경은 없어야 한다.

## 검증

`./gradlew check` green.

---
_Generated by [Claude Code](https://claude.ai/code/session_01RNw4fkDjtJBRJXWx9dc5p1)_