### PR TITLE
feat(mail): 리포트 메일 발송 인프라 신설 (ADR 3 Step 1)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -21,6 +21,7 @@ repositories {
 dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
+	implementation 'org.springframework.boot:spring-boot-starter-mail'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	implementation 'org.springframework.security:spring-security-crypto'
 	implementation 'org.flywaydb:flyway-core'

--- a/src/main/java/com/company/officecommute/controller/overtime/OverTimeController.java
+++ b/src/main/java/com/company/officecommute/controller/overtime/OverTimeController.java
@@ -3,6 +3,7 @@ package com.company.officecommute.controller.overtime;
 import com.company.officecommute.auth.ManagerOnly;
 import com.company.officecommute.dto.overtime.response.OverTimeCalculateResponse;
 import com.company.officecommute.dto.overtime.response.OverTimeReport;
+import com.company.officecommute.service.overtime.OverTimeReportFileName;
 import com.company.officecommute.service.overtime.OverTimeReportService;
 import com.company.officecommute.service.overtime.OverTimeService;
 import org.springframework.http.ContentDisposition;
@@ -51,7 +52,7 @@ public class OverTimeController {
 
         HttpHeaders headers = new HttpHeaders();
         headers.setContentType(MediaType.parseMediaType("application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"));
-        headers.setContentDisposition(ContentDisposition.attachment().filename(yearMonth.getYear() + "년" + yearMonth.getMonthValue() + "월_초과근무보고서.xlsx", UTF_8).build());
+        headers.setContentDisposition(ContentDisposition.attachment().filename(OverTimeReportFileName.of(yearMonth), UTF_8).build());
         return ResponseEntity.ok()
                 .headers(headers)
                 .body(body);

--- a/src/main/java/com/company/officecommute/domain/report/DispatchFailureReason.java
+++ b/src/main/java/com/company/officecommute/domain/report/DispatchFailureReason.java
@@ -1,0 +1,30 @@
+package com.company.officecommute.domain.report;
+
+/**
+ * 발송 실패의 분류. 재시도가 의미를 가지려면 관리자가 "무엇을 고쳐야 하는지" 또는
+ * "고칠 것이 없으니 기다리면 되는지"를 알아야 하므로, 실패를 뭉뚱그리지 않고 나눈다.
+ */
+public enum DispatchFailureReason {
+
+    /** 퇴근 미마감 기록이 있어 대표 발송을 보류했다. 마감하면 다음 재시도에서 자동 발송된다. */
+    UNCLOSED_COMMUTES("퇴근 미마감 기록이 있어 발송을 보류했습니다. 마감하면 다음 재시도에서 자동 발송됩니다."),
+
+    /** 공휴일 API가 응답하지 않아 집계를 신뢰할 수 없다. 사람이 할 조치는 없다. */
+    HOLIDAY_DATA_UNAVAILABLE("공휴일 API를 이용할 수 없어 집계를 중단했습니다. 조치 없이 재시도됩니다."),
+
+    /** SMTP 오류. 계정·서버 설정을 봐야 한다. */
+    MAIL_SEND_FAILED("메일 발송에 실패했습니다. SMTP 계정과 서버 설정을 확인해 주세요."),
+
+    /** 그 외. 스택 트레이스는 로그에 남는다. */
+    UNEXPECTED("예상하지 못한 오류로 발송에 실패했습니다. 서버 로그를 확인해 주세요.");
+
+    private final String managerGuidance;
+
+    DispatchFailureReason(String managerGuidance) {
+        this.managerGuidance = managerGuidance;
+    }
+
+    public String getManagerGuidance() {
+        return managerGuidance;
+    }
+}

--- a/src/main/java/com/company/officecommute/mail/ReportMailException.java
+++ b/src/main/java/com/company/officecommute/mail/ReportMailException.java
@@ -1,0 +1,16 @@
+package com.company.officecommute.mail;
+
+/**
+ * 메일 구성·설정 문제. 발송 유스케이스는 이것을 {@code MAIL_SEND_FAILED}로 분류해
+ * 실패로 기록한다 — 스케줄러 스레드를 죽이지 않는다.
+ */
+public class ReportMailException extends RuntimeException {
+
+    public ReportMailException(String message) {
+        super(message);
+    }
+
+    public ReportMailException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/src/main/java/com/company/officecommute/mail/ReportMailProperties.java
+++ b/src/main/java/com/company/officecommute/mail/ReportMailProperties.java
@@ -1,0 +1,48 @@
+package com.company.officecommute.mail;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+
+import java.util.List;
+
+/**
+ * 수신자·발신자는 전부 설정값이다. 코드에 박으면 사람이 바뀔 때마다 재배포가 필요하고,
+ * 저장소에 실주소가 남는다.
+ */
+@Configuration
+@ConfigurationProperties(prefix = "report.mail")
+public class ReportMailProperties {
+
+    /** 발신 주소. */
+    private String from;
+
+    /** 대표 — 정상 리포트의 유일한 수신자. */
+    private String ceo;
+
+    /** 근태 관리자 — 보류·실패 알림 수신자. 복수 가능(쉼표 구분 환경변수). */
+    private List<String> managers = List.of();
+
+    public String getFrom() {
+        return from;
+    }
+
+    public void setFrom(String from) {
+        this.from = from;
+    }
+
+    public String getCeo() {
+        return ceo;
+    }
+
+    public void setCeo(String ceo) {
+        this.ceo = ceo;
+    }
+
+    public List<String> getManagers() {
+        return managers;
+    }
+
+    public void setManagers(List<String> managers) {
+        this.managers = List.copyOf(managers);
+    }
+}

--- a/src/main/java/com/company/officecommute/mail/ReportMailer.java
+++ b/src/main/java/com/company/officecommute/mail/ReportMailer.java
@@ -1,0 +1,178 @@
+package com.company.officecommute.mail;
+
+import com.company.officecommute.domain.report.DispatchFailureReason;
+import com.company.officecommute.dto.overtime.response.OverTimeReport;
+import com.company.officecommute.service.overtime.OverTimeReportFileName;
+import com.company.officecommute.service.overtime.UnclosedCommute;
+import jakarta.mail.internet.MimeMessage;
+import org.springframework.core.io.ByteArrayResource;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.mail.javamail.MimeMessageHelper;
+import org.springframework.stereotype.Component;
+
+import java.time.YearMonth;
+import java.util.List;
+
+/**
+ * 초과근무 리포트 관련 메일 발송.
+ * <p>
+ * 용도별로 메서드를 나눈다 — 수신자·제목·본문이 전부 다르므로 플래그 인자로 분기하면
+ * "대표에게 갈 메일이 관리자에게 가는" 종류의 실수가 한 줄 조건문 뒤로 숨는다.
+ */
+@Component
+public class ReportMailer {
+
+    private static final String SUBJECT_PREFIX = "[초과근무] ";
+    private static final String CALCULATION_BASIS = "1일 8시간·1주 40시간 초과, 휴일근로 별도 트랙";
+
+    /** 본문이 무한정 길어지는 것을 막는다. 전체 목록은 첨부 리포트와 화면에서 확인한다. */
+    private static final int MAX_LISTED_UNCLOSED = 50;
+
+    private final JavaMailSender mailSender;
+    private final ReportMailProperties properties;
+
+    public ReportMailer(JavaMailSender mailSender, ReportMailProperties properties) {
+        this.mailSender = mailSender;
+        this.properties = properties;
+    }
+
+    /**
+     * 정상 리포트 — 대표에게. 이 메일이 나가는 경우는 미마감 0건뿐이다.
+     */
+    public void sendMonthlyReport(OverTimeReport report, byte[] excel) {
+        String body = """
+                %s 초과근무 보고서를 첨부합니다.
+
+                %s
+                """.formatted(displayMonth(report.yearMonth()), summary(report));
+
+        send(
+                List.of(requireConfigured(properties.getCeo(), "report.mail.ceo")),
+                SUBJECT_PREFIX + displayMonth(report.yearMonth()) + " 초과근무 보고서",
+                body,
+                report.yearMonth(),
+                excel
+        );
+    }
+
+    /**
+     * 퇴근 미마감으로 대표 발송을 보류했음 — 근태 관리자에게.
+     * 리포트를 함께 첨부해 관리자가 수치를 바로 확인하고 교정할 수 있게 한다.
+     */
+    public void sendUnclosedCommuteWarning(OverTimeReport report, byte[] excel, List<UnclosedCommute> unclosed) {
+        String body = """
+                %s 초과근무 리포트의 대표 발송을 보류했습니다.
+
+                %s
+
+                %s
+
+                %s
+                """.formatted(
+                displayMonth(report.yearMonth()),
+                DispatchFailureReason.UNCLOSED_COMMUTES.getManagerGuidance(),
+                summary(report),
+                unclosedList(unclosed)
+        );
+
+        send(
+                managers(),
+                SUBJECT_PREFIX + displayMonth(report.yearMonth()) + " 리포트 발송 보류 — 퇴근 미마감 "
+                        + report.unclosedCommuteCount() + "건",
+                body,
+                report.yearMonth(),
+                excel
+        );
+    }
+
+    /**
+     * 발송 실패 — 근태 관리자에게. "메일이 안 온 것"과 "발송이 실패한 것"이 구분돼야 한다.
+     */
+    public void sendDispatchFailure(YearMonth target, DispatchFailureReason reason, String detail) {
+        String body = """
+                %s 초과근무 리포트 발송이 실패했습니다.
+
+                사유: %s
+                %s
+
+                상세: %s
+                """.formatted(displayMonth(target), reason.name(), reason.getManagerGuidance(), detail);
+
+        send(
+                managers(),
+                SUBJECT_PREFIX + displayMonth(target) + " 리포트 발송 실패 — " + reason.name(),
+                body,
+                target,
+                null
+        );
+    }
+
+    private void send(List<String> recipients, String subject, String body, YearMonth target, byte[] excel) {
+        MimeMessage message = mailSender.createMimeMessage();
+        try {
+            MimeMessageHelper helper = new MimeMessageHelper(message, true, "UTF-8");
+            helper.setFrom(requireConfigured(properties.getFrom(), "report.mail.from"));
+            helper.setTo(recipients.toArray(new String[0]));
+            helper.setSubject(subject);
+            helper.setText(body, false);
+            if (excel != null) {
+                helper.addAttachment(OverTimeReportFileName.of(target), new ByteArrayResource(excel));
+            }
+        } catch (jakarta.mail.MessagingException e) {
+            throw new ReportMailException("메일 구성에 실패했습니다: " + subject, e);
+        }
+        mailSender.send(message);
+    }
+
+    private List<String> managers() {
+        List<String> managers = properties.getManagers();
+        if (managers.isEmpty()) {
+            // 관리자 주소가 비면 "조용한 실패"를 드러낼 통로 자체가 없어진다 — 설정 누락으로 다룬다.
+            throw new ReportMailException("report.mail.managers 가 비어 있어 관리자 알림을 보낼 수 없습니다.");
+        }
+        return managers;
+    }
+
+    private String requireConfigured(String value, String propertyName) {
+        if (value == null || value.isBlank()) {
+            throw new ReportMailException(propertyName + " 가 설정되지 않았습니다.");
+        }
+        return value;
+    }
+
+    /**
+     * 수신자가 첨부를 열지 않고도 신뢰성을 판단할 수 있어야 한다.
+     */
+    private String summary(OverTimeReport report) {
+        return """
+                - 대상 월: %s
+                - 대상자: %d명
+                - 퇴근 미마감: %d건
+                - 산정 기준: %s""".formatted(
+                displayMonth(report.yearMonth()),
+                report.rows().size(),
+                report.unclosedCommuteCount(),
+                CALCULATION_BASIS
+        );
+    }
+
+    private String unclosedList(List<UnclosedCommute> unclosed) {
+        StringBuilder builder = new StringBuilder("미마감 목록 (")
+                .append(unclosed.size())
+                .append("건)");
+        unclosed.stream()
+                .limit(MAX_LISTED_UNCLOSED)
+                .forEach(record -> builder.append("\n- ")
+                        .append(record.employeeCode()).append(' ')
+                        .append(record.employeeName()).append(' ')
+                        .append(record.workDate()));
+        if (unclosed.size() > MAX_LISTED_UNCLOSED) {
+            builder.append("\n- ... 외 ").append(unclosed.size() - MAX_LISTED_UNCLOSED).append("건");
+        }
+        return builder.toString();
+    }
+
+    private String displayMonth(YearMonth yearMonth) {
+        return yearMonth.getYear() + "년 " + yearMonth.getMonthValue() + "월";
+    }
+}

--- a/src/main/java/com/company/officecommute/service/overtime/OverTimeReportFileName.java
+++ b/src/main/java/com/company/officecommute/service/overtime/OverTimeReportFileName.java
@@ -1,0 +1,18 @@
+package com.company.officecommute.service.overtime;
+
+import java.time.YearMonth;
+
+/**
+ * 초과근무 보고서 엑셀 파일명. 온디맨드 다운로드(컨트롤러)와 매월 배치 메일 첨부가
+ * <b>같은 이름</b>을 내보내야 대표·관리자가 두 경로에서 받은 파일을 같은 것으로 식별한다.
+ * 양쪽에 문자열을 따로 두면 한쪽만 바뀌는 순간 조용히 갈라지므로 한 곳에서만 만든다.
+ */
+public final class OverTimeReportFileName {
+
+    private OverTimeReportFileName() {
+    }
+
+    public static String of(YearMonth yearMonth) {
+        return yearMonth.getYear() + "년" + yearMonth.getMonthValue() + "월_초과근무보고서.xlsx";
+    }
+}

--- a/src/main/java/com/company/officecommute/service/overtime/UnclosedCommute.java
+++ b/src/main/java/com/company/officecommute/service/overtime/UnclosedCommute.java
@@ -1,0 +1,14 @@
+package com.company.officecommute.service.overtime;
+
+import java.time.LocalDate;
+
+/**
+ * 퇴근이 찍히지 않은 출근 기록 한 건. 관리자에게 "무엇을 마감해야 하는지" 알려주려면
+ * 건수({@code countUnclosedCommutes})만으로는 부족해 사번·이름·근무일이 필요하다.
+ */
+public record UnclosedCommute(
+        String employeeCode,
+        String employeeName,
+        LocalDate workDate
+) {
+}

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -35,6 +35,28 @@ spring:
       # 배포 전 운영자가 생성한 BCrypt 해시 (V11) — 기본값 없음: 미설정 시 부팅 실패가 정상
       admin_password_hash: ${ADMIN_PASSWORD_HASH}
 
+  # 메일 — 기본값을 두지 않는다. 미설정 시 부팅이 실패하는 편이,
+  # 매월 1일에야 "발송이 안 된다"를 발견하는 것보다 싸다 (ADMIN_PASSWORD_HASH 와 같은 방침).
+  mail:
+    host: ${MAIL_HOST}
+    port: ${MAIL_PORT}
+    username: ${MAIL_USERNAME}
+    password: ${MAIL_PASSWORD}
+    properties:
+      mail:
+        smtp:
+          auth: ${MAIL_SMTP_AUTH:true}
+          starttls:
+            enable: ${MAIL_SMTP_STARTTLS:true}
+
+# 리포트 수신자 (운영 필수)
+report:
+  mail:
+    from: ${REPORT_MAIL_FROM}
+    ceo: ${REPORT_MAIL_CEO}
+    # 복수 지정은 쉼표 구분: a@company.com,b@company.com
+    managers: ${REPORT_MAIL_MANAGERS}
+
 # P6Spy 비활성화 (운영 성능을 위해)
 decorator:
   datasource:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -22,6 +22,22 @@ spring:
   jackson:
     default-property-inclusion: non_null
 
+  # 메일 — 여기 기본값은 dev/test 컨텍스트가 뜨게 하는 용도다.
+  # spring.mail.host 가 없으면 JavaMailSender 빈 자체가 만들어지지 않아 ReportMailer 주입이 깨진다.
+  # 실제 발송이 일어나는 prod 는 application-prod.yml 에서 환경변수로 덮어쓴다(기본값 없음 = 미설정 시 부팅 실패).
+  mail:
+    host: ${MAIL_HOST:localhost}
+    port: ${MAIL_PORT:25}
+    username: ${MAIL_USERNAME:}
+    password: ${MAIL_PASSWORD:}
+
+# 리포트 수신자 — 실값은 prod 환경변수로만 들어온다
+report:
+  mail:
+    from: ${REPORT_MAIL_FROM:}
+    ceo: ${REPORT_MAIL_CEO:}
+    managers: ${REPORT_MAIL_MANAGERS:}
+
 # 서버 공통 설정
 server:
   servlet:

--- a/src/test/java/com/company/officecommute/mail/ReportMailerTest.java
+++ b/src/test/java/com/company/officecommute/mail/ReportMailerTest.java
@@ -1,0 +1,176 @@
+package com.company.officecommute.mail;
+
+import com.company.officecommute.domain.report.DispatchFailureReason;
+import com.company.officecommute.dto.overtime.response.OverTimeReport;
+import com.company.officecommute.dto.overtime.response.OverTimeReportData;
+import com.company.officecommute.service.overtime.UnclosedCommute;
+import jakarta.mail.Message;
+import jakarta.mail.internet.MimeMessage;
+import jakarta.mail.internet.MimeMultipart;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.mail.javamail.JavaMailSender;
+
+import java.time.LocalDate;
+import java.time.YearMonth;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.never;
+
+@ExtendWith(MockitoExtension.class)
+class ReportMailerTest {
+
+    private static final YearMonth JULY = YearMonth.of(2026, 7);
+
+    @Mock
+    private JavaMailSender mailSender;
+
+    private ReportMailProperties properties;
+    private ReportMailer mailer;
+
+    @BeforeEach
+    void setUp() {
+        properties = new ReportMailProperties();
+        properties.setFrom("noreply@company.com");
+        properties.setCeo("ceo@company.com");
+        properties.setManagers(List.of("hr1@company.com", "hr2@company.com"));
+        mailer = new ReportMailer(mailSender, properties);
+    }
+
+    @Test
+    @DisplayName("정상 리포트는 대표에게만 가고, 첨부 파일명·제목에 대상 월이 들어간다")
+    void sendMonthlyReport_toCeoWithNamedAttachment() throws Exception {
+        givenRealMimeMessage();
+
+        mailer.sendMonthlyReport(report(JULY, 2, 0), "xlsx-bytes".getBytes());
+
+        MimeMessage sent = captureSent();
+        assertThat(recipients(sent)).containsExactly("ceo@company.com");
+        assertThat(sent.getSubject()).contains("2026년 7월");
+        assertThat(attachmentFileName(sent)).isEqualTo("2026년7월_초과근무보고서.xlsx");
+    }
+
+    @Test
+    @DisplayName("정상 리포트 본문에 대상자 수·미마감 건수·산정 기준이 들어간다")
+    void sendMonthlyReport_bodyCarriesReliabilitySignals() throws Exception {
+        givenRealMimeMessage();
+
+        mailer.sendMonthlyReport(report(JULY, 2, 0), "xlsx-bytes".getBytes());
+
+        String body = bodyText(captureSent());
+        assertThat(body)
+                .contains("대상 월: 2026년 7월")
+                .contains("대상자: 2명")
+                .contains("퇴근 미마감: 0건")
+                .contains("1일 8시간·1주 40시간 초과, 휴일근로 별도 트랙");
+    }
+
+    @Test
+    @DisplayName("미마감 보류 경고는 관리자 전원에게 가고 본문에 미마감 목록이 들어간다")
+    void sendUnclosedCommuteWarning_toManagersWithList() throws Exception {
+        givenRealMimeMessage();
+
+        mailer.sendUnclosedCommuteWarning(
+                report(JULY, 2, 1),
+                "xlsx-bytes".getBytes(),
+                List.of(new UnclosedCommute("EMP001", "임형준", LocalDate.of(2026, 7, 31)))
+        );
+
+        MimeMessage sent = captureSent();
+        assertThat(recipients(sent)).containsExactly("hr1@company.com", "hr2@company.com");
+        assertThat(sent.getSubject()).contains("2026년 7월").contains("발송 보류");
+        assertThat(bodyText(sent)).contains("EMP001 임형준 2026-07-31");
+        // 관리자가 수치를 바로 확인할 수 있도록 리포트도 함께 간다
+        assertThat(attachmentFileName(sent)).isEqualTo("2026년7월_초과근무보고서.xlsx");
+    }
+
+    @Test
+    @DisplayName("발송 실패 알림은 관리자에게 사유 분류와 조치 안내를 담아 간다")
+    void sendDispatchFailure_toManagersWithReason() throws Exception {
+        givenRealMimeMessage();
+
+        mailer.sendDispatchFailure(JULY, DispatchFailureReason.HOLIDAY_DATA_UNAVAILABLE, "resultCode=22");
+
+        MimeMessage sent = captureSent();
+        assertThat(recipients(sent)).containsExactly("hr1@company.com", "hr2@company.com");
+        assertThat(sent.getSubject()).contains("2026년 7월").contains("HOLIDAY_DATA_UNAVAILABLE");
+        assertThat(bodyText(sent))
+                .contains(DispatchFailureReason.HOLIDAY_DATA_UNAVAILABLE.getManagerGuidance())
+                .contains("resultCode=22");
+    }
+
+    @Test
+    @DisplayName("관리자 주소가 비어 있으면 조용히 넘어가지 않고 설정 누락으로 실패한다")
+    void managersNotConfigured_fails() {
+        properties.setManagers(List.of());
+
+        assertThatThrownBy(() -> mailer.sendDispatchFailure(JULY, DispatchFailureReason.UNEXPECTED, "boom"))
+                .isInstanceOf(ReportMailException.class)
+                .hasMessageContaining("report.mail.managers");
+
+        then(mailSender).should(never()).send(org.mockito.ArgumentMatchers.any(MimeMessage.class));
+    }
+
+    private void givenRealMimeMessage() {
+        // MimeMessageHelper 가 실제로 조립한 결과를 검증해야 하므로 목이 아닌 진짜 MimeMessage 를 준다
+        given(mailSender.createMimeMessage()).willReturn(new MimeMessage((jakarta.mail.Session) null));
+    }
+
+    private MimeMessage captureSent() {
+        ArgumentCaptor<MimeMessage> captor = ArgumentCaptor.forClass(MimeMessage.class);
+        then(mailSender).should().send(captor.capture());
+        return captor.getValue();
+    }
+
+    private List<String> recipients(MimeMessage message) throws Exception {
+        return List.of(message.getRecipients(Message.RecipientType.TO)).stream()
+                .map(Object::toString)
+                .toList();
+    }
+
+    private String attachmentFileName(MimeMessage message) throws Exception {
+        MimeMultipart multipart = (MimeMultipart) message.getContent();
+        for (int i = 0; i < multipart.getCount(); i++) {
+            String fileName = multipart.getBodyPart(i).getFileName();
+            if (fileName != null) {
+                return fileName;
+            }
+        }
+        return null;
+    }
+
+    private String bodyText(MimeMessage message) throws Exception {
+        return readText(message.getContent());
+    }
+
+    private String readText(Object content) throws Exception {
+        if (content instanceof String text) {
+            return text;
+        }
+        MimeMultipart multipart = (MimeMultipart) content;
+        StringBuilder builder = new StringBuilder();
+        for (int i = 0; i < multipart.getCount(); i++) {
+            if (multipart.getBodyPart(i).getFileName() == null) {
+                builder.append(readText(multipart.getBodyPart(i).getContent()));
+            }
+        }
+        return builder.toString();
+    }
+
+    private OverTimeReport report(YearMonth yearMonth, int rowCount, long unclosedCount) {
+        List<OverTimeReportData> rows = java.util.stream.IntStream.range(0, rowCount)
+                .mapToObj(i -> new OverTimeReportData(
+                        "EMP00" + i, "직원" + i, "백엔드팀", 60, 0, 0, 22500))
+                .toList();
+        return new OverTimeReport(yearMonth, rows, unclosedCount);
+    }
+}

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -1,6 +1,12 @@
 spring:
   profiles:
     active: test
+  # 이 파일이 메인 application.yml 을 가리므로 메일 설정도 여기 있어야 한다.
+  # spring.mail.host 가 없으면 JavaMailSender 빈이 만들어지지 않아 ReportMailer 주입이 깨진다.
+  # 테스트에서 실제로 발송하는 경로는 없다(수신자 주소는 일부러 비워 둔다).
+  mail:
+    host: localhost
+    port: 25
   flyway:
     enabled: false
     placeholders:


### PR DESCRIPTION
ADR 3 분할 PR **2/7**. base: `claude/adr3-01-api-timeout` (#41)

프로젝트 첫 메일 의존성. **아직 호출자가 없다** — 발송 유스케이스는 4/7에서 붙는다.

## 변경

- `spring-boot-starter-mail` 추가
- `ReportMailProperties`(`report.mail.*`): from / ceo / managers 전부 설정 주입
- `ReportMailer`: 용도별 세 메서드 — 정상 리포트(대표) / 미마감 보류 경고(관리자) / 발송 실패 알림(관리자)
- `DispatchFailureReason`: 실패를 네 갈래로 분류하고 사유별 조치 안내를 함께 둔다
- `OverTimeReportFileName`: 파일명 규칙을 한 곳으로 추출해 컨트롤러와 배치가 공유

## 설계 근거

- **플래그 인자로 분기하지 않는다** — 수신자·제목·본문이 전부 달라서, 한 줄 조건문 뒤에 "대표에게 갈 메일이 관리자에게 가는" 실수가 숨는다
- **본문에 대상 월·대상자 수·미마감 건수·산정 기준을 싣는다** — 첨부를 열지 않고도 수치를 믿어도 되는지 판단할 수 있어야 한다
- 파일명을 양쪽에 문자열로 두면 한쪽만 바뀌는 순간 조용히 갈라진다

## 리뷰 포인트

- 메일 본문 문구와 수신자 분기가 의도대로인지
- 환경변수 구조: prod는 기본값이 없어 **미설정 시 부팅 실패**다(`ADMIN_PASSWORD_HASH`와 같은 방침). 실값이 준비되기 전에 prod를 띄워야 한다면 이 결정을 뒤집어야 한다
- dev/test는 `spring.mail.host` 기본값(localhost)만 둬 `JavaMailSender` 빈이 생기게 했다. 이게 없으면 모든 `@SpringBootTest` 컨텍스트가 깨진다

## 검증

`./gradlew check` green. `ReportMailerTest` 5건 — 첨부 파일명·수신자·제목·본문 신뢰성 신호, 관리자 주소 미설정 시 조용히 넘어가지 않고 실패하는지.

---
_Generated by [Claude Code](https://claude.ai/code/session_01RNw4fkDjtJBRJXWx9dc5p1)_