### PR TITLE
feat(report): 발송 이력 테이블로 중복 발송을 구조적으로 막는다 (ADR 3 Step 2)

### DIFF
--- a/src/main/java/com/company/officecommute/domain/report/DispatchStatus.java
+++ b/src/main/java/com/company/officecommute/domain/report/DispatchStatus.java
@@ -1,0 +1,13 @@
+package com.company.officecommute.domain.report;
+
+public enum DispatchStatus {
+
+    /** 어떤 실행이 이 달을 선점해 진행 중이다. 리스 시간이 지나면 회수 대상이 된다. */
+    IN_PROGRESS,
+
+    /** 대표에게 발송 완료. 종착 상태 — 이 달은 다시 발송되지 않는다. */
+    SENT,
+
+    /** 시도했으나 실패. 재시도 창 안이면 다음 시도가 다시 집어간다. */
+    FAILED
+}

--- a/src/main/java/com/company/officecommute/domain/report/ReportDispatch.java
+++ b/src/main/java/com/company/officecommute/domain/report/ReportDispatch.java
@@ -1,0 +1,144 @@
+package com.company.officecommute.domain.report;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Convert;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.time.YearMonth;
+import java.util.Objects;
+
+/**
+ * 한 대상 월의 발송 이력. 상태 전이를 엔티티가 소유해, "어디선가 status 만 바꿔치기"가
+ * 생기지 않게 한다.
+ * <p>
+ * {@code UNIQUE(target_year_month)}가 중복 발송 방지의 유일한 하드 보증이다.
+ */
+@Entity
+@Table(uniqueConstraints = {
+        @UniqueConstraint(name = "uk_report_dispatch_year_month", columnNames = {"target_year_month"})
+})
+public class ReportDispatch {
+
+    /** 실패 사유 컬럼 길이. 넘치면 저장 시점에 터지므로 자른다. */
+    private static final int MAX_FAILURE_REASON_LENGTH = 1000;
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long reportDispatchId;
+
+    @Convert(converter = YearMonthAttributeConverter.class)
+    @Column(name = "target_year_month", nullable = false, length = 7)
+    private YearMonth targetYearMonth;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 20)
+    private DispatchStatus status;
+
+    /** 결과가 기록된 시도 횟수. 진행 중인 시도는 아직 세지 않는다. */
+    @Column(nullable = false)
+    private int attemptCount;
+
+    @Column(nullable = false)
+    private Instant lastAttemptedAt;
+
+    private Instant sentAt;
+
+    @Column(length = MAX_FAILURE_REASON_LENGTH)
+    private String lastFailureReason;
+
+    protected ReportDispatch() {
+    }
+
+    private ReportDispatch(YearMonth targetYearMonth, Instant now) {
+        this.targetYearMonth = Objects.requireNonNull(targetYearMonth, "targetYearMonth는 null일 수 없습니다.");
+        this.status = DispatchStatus.IN_PROGRESS;
+        this.attemptCount = 0;
+        this.lastAttemptedAt = Objects.requireNonNull(now, "now는 null일 수 없습니다.");
+    }
+
+    /** 이 달을 선점한다. 동시에 두 실행이 부르면 유니크 제약이 한쪽을 떨어뜨린다. */
+    public static ReportDispatch claim(YearMonth targetYearMonth, Instant now) {
+        return new ReportDispatch(targetYearMonth, now);
+    }
+
+    /**
+     * 이미 있는 이력으로 새 시도를 시작한다(재시도 또는 리스 회수).
+     * 실패 사유는 남겨 둔다 — 이번 시도가 또 실패할 때까지는 마지막으로 알려진 이유가 유효하다.
+     */
+    public void beginAttempt(Instant now) {
+        this.status = DispatchStatus.IN_PROGRESS;
+        this.lastAttemptedAt = now;
+    }
+
+    public void markSent(Instant now) {
+        this.status = DispatchStatus.SENT;
+        this.sentAt = now;
+        this.lastAttemptedAt = now;
+        this.attemptCount++;
+        this.lastFailureReason = null;
+    }
+
+    public void markFailed(String reason, Instant now) {
+        this.status = DispatchStatus.FAILED;
+        this.lastAttemptedAt = now;
+        this.attemptCount++;
+        this.lastFailureReason = truncate(reason);
+    }
+
+    public boolean isSent() {
+        return status == DispatchStatus.SENT;
+    }
+
+    /**
+     * 다른 실행이 선점한 채 아직 살아 있는가.
+     * 발송 도중 프로세스가 죽으면 {@code IN_PROGRESS}가 남는데, 리스가 없으면 그 달이
+     * 영원히 잠긴다 — 리스 시간이 지난 선점은 회수한다.
+     */
+    public boolean isLeaseHeld(Instant now, Duration lease) {
+        return status == DispatchStatus.IN_PROGRESS && lastAttemptedAt.plus(lease).isAfter(now);
+    }
+
+    private String truncate(String reason) {
+        if (reason == null || reason.length() <= MAX_FAILURE_REASON_LENGTH) {
+            return reason;
+        }
+        return reason.substring(0, MAX_FAILURE_REASON_LENGTH);
+    }
+
+    public Long getReportDispatchId() {
+        return reportDispatchId;
+    }
+
+    public YearMonth getTargetYearMonth() {
+        return targetYearMonth;
+    }
+
+    public DispatchStatus getStatus() {
+        return status;
+    }
+
+    public int getAttemptCount() {
+        return attemptCount;
+    }
+
+    public Instant getLastAttemptedAt() {
+        return lastAttemptedAt;
+    }
+
+    public Instant getSentAt() {
+        return sentAt;
+    }
+
+    public String getLastFailureReason() {
+        return lastFailureReason;
+    }
+}

--- a/src/main/java/com/company/officecommute/domain/report/YearMonthAttributeConverter.java
+++ b/src/main/java/com/company/officecommute/domain/report/YearMonthAttributeConverter.java
@@ -1,0 +1,25 @@
+package com.company.officecommute.domain.report;
+
+import jakarta.persistence.AttributeConverter;
+import jakarta.persistence.Converter;
+
+import java.time.YearMonth;
+
+/**
+ * {@code YearMonth} ↔ {@code CHAR(7)} 'yyyy-MM'.
+ * {@link YearMonth#toString()}과 {@link YearMonth#parse(CharSequence)}가 이미 ISO 'yyyy-MM'
+ * 라운드트립을 보장하므로 별도 포맷터를 두지 않는다.
+ */
+@Converter
+public class YearMonthAttributeConverter implements AttributeConverter<YearMonth, String> {
+
+    @Override
+    public String convertToDatabaseColumn(YearMonth attribute) {
+        return attribute == null ? null : attribute.toString();
+    }
+
+    @Override
+    public YearMonth convertToEntityAttribute(String dbData) {
+        return dbData == null ? null : YearMonth.parse(dbData);
+    }
+}

--- a/src/main/java/com/company/officecommute/repository/report/ReportDispatchRepository.java
+++ b/src/main/java/com/company/officecommute/repository/report/ReportDispatchRepository.java
@@ -1,0 +1,12 @@
+package com.company.officecommute.repository.report;
+
+import com.company.officecommute.domain.report.ReportDispatch;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.time.YearMonth;
+import java.util.Optional;
+
+public interface ReportDispatchRepository extends JpaRepository<ReportDispatch, Long> {
+
+    Optional<ReportDispatch> findByTargetYearMonth(YearMonth targetYearMonth);
+}

--- a/src/main/resources/db/migration/V13__report_dispatch.sql
+++ b/src/main/resources/db/migration/V13__report_dispatch.sql
@@ -1,0 +1,19 @@
+-- 매월 초과근무 리포트 발송 이력.
+-- UNIQUE(target_year_month) 가 중복 발송 방지의 유일한 하드 보증이다 —
+-- 스케줄 간격·상태 전이는 전부 그 위의 편의 계층이고, 배치 재시도와 수동 재실행이
+-- 겹쳐도 대표는 한 달에 한 통만 받는다.
+--
+-- target_year_month 를 DATE 로 두지 않는 이유: '1일'이라는 존재하지 않는 날짜가
+-- 의미를 갖는 것처럼 보인다. 'yyyy-MM' 문자열이 대상 월이라는 사실을 그대로 표현한다.
+CREATE TABLE report_dispatch
+(
+    report_dispatch_id  BIGINT       NOT NULL AUTO_INCREMENT,
+    target_year_month   CHAR(7)      NOT NULL, -- 'yyyy-MM'
+    status              VARCHAR(20)  NOT NULL, -- IN_PROGRESS | SENT | FAILED
+    attempt_count       INT          NOT NULL,
+    last_attempted_at   DATETIME(6)  NOT NULL,
+    sent_at             DATETIME(6),
+    last_failure_reason VARCHAR(1000),
+    PRIMARY KEY (report_dispatch_id),
+    CONSTRAINT uk_report_dispatch_year_month UNIQUE (target_year_month)
+);

--- a/src/main/resources/db/migration/V13__report_dispatch.sql
+++ b/src/main/resources/db/migration/V13__report_dispatch.sql
@@ -8,7 +8,7 @@
 CREATE TABLE report_dispatch
 (
     report_dispatch_id  BIGINT       NOT NULL AUTO_INCREMENT,
-    target_year_month   CHAR(7)      NOT NULL, -- 'yyyy-MM'
+    target_year_month   VARCHAR(7)   NOT NULL, -- 'yyyy-MM'
     status              VARCHAR(20)  NOT NULL, -- IN_PROGRESS | SENT | FAILED
     attempt_count       INT          NOT NULL,
     last_attempted_at   DATETIME(6)  NOT NULL,

--- a/src/test/java/com/company/officecommute/domain/report/ReportDispatchTest.java
+++ b/src/test/java/com/company/officecommute/domain/report/ReportDispatchTest.java
@@ -1,0 +1,88 @@
+package com.company.officecommute.domain.report;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.time.YearMonth;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class ReportDispatchTest {
+
+    private static final YearMonth JULY = YearMonth.of(2026, 7);
+    private static final Instant NOW = Instant.parse("2026-08-01T06:00:00Z");
+    private static final Duration LEASE = Duration.ofMinutes(30);
+
+    @Test
+    @DisplayName("선점 직후는 IN_PROGRESS이고 아직 시도 횟수가 0이다")
+    void claim_startsInProgress() {
+        ReportDispatch dispatch = ReportDispatch.claim(JULY, NOW);
+
+        assertThat(dispatch.getStatus()).isEqualTo(DispatchStatus.IN_PROGRESS);
+        assertThat(dispatch.getAttemptCount()).isZero();
+        assertThat(dispatch.isSent()).isFalse();
+    }
+
+    @Test
+    @DisplayName("발송 성공은 SENT + sentAt을 남기고 이전 실패 사유를 지운다")
+    void markSent_clearsFailureReason() {
+        ReportDispatch dispatch = ReportDispatch.claim(JULY, NOW);
+        dispatch.markFailed("HOLIDAY_DATA_UNAVAILABLE", NOW);
+
+        dispatch.markSent(NOW.plus(Duration.ofHours(4)));
+
+        assertThat(dispatch.isSent()).isTrue();
+        assertThat(dispatch.getSentAt()).isEqualTo(NOW.plus(Duration.ofHours(4)));
+        assertThat(dispatch.getLastFailureReason()).isNull();
+        assertThat(dispatch.getAttemptCount()).isEqualTo(2);
+    }
+
+    @Test
+    @DisplayName("실패는 시도 횟수를 올리고 사유를 남긴다")
+    void markFailed_recordsReason() {
+        ReportDispatch dispatch = ReportDispatch.claim(JULY, NOW);
+
+        dispatch.markFailed("UNCLOSED_COMMUTES: 3건", NOW);
+
+        assertThat(dispatch.getStatus()).isEqualTo(DispatchStatus.FAILED);
+        assertThat(dispatch.getAttemptCount()).isEqualTo(1);
+        assertThat(dispatch.getLastFailureReason()).isEqualTo("UNCLOSED_COMMUTES: 3건");
+    }
+
+    @Test
+    @DisplayName("실패 사유가 컬럼 길이를 넘으면 잘라 저장한다 — 기록하려다 저장이 터지면 본말전도")
+    void markFailed_truncatesLongReason() {
+        ReportDispatch dispatch = ReportDispatch.claim(JULY, NOW);
+
+        dispatch.markFailed("x".repeat(1500), NOW);
+
+        assertThat(dispatch.getLastFailureReason()).hasSize(1000);
+    }
+
+    @Test
+    @DisplayName("리스 시간 안의 IN_PROGRESS는 다른 실행이 잡고 있는 것으로 본다")
+    void isLeaseHeld_withinLease() {
+        ReportDispatch dispatch = ReportDispatch.claim(JULY, NOW);
+
+        assertThat(dispatch.isLeaseHeld(NOW.plus(Duration.ofMinutes(29)), LEASE)).isTrue();
+    }
+
+    @Test
+    @DisplayName("리스 시간이 지난 IN_PROGRESS는 회수 대상 — 그 달이 영원히 잠기면 안 된다")
+    void isLeaseHeld_expired() {
+        ReportDispatch dispatch = ReportDispatch.claim(JULY, NOW);
+
+        assertThat(dispatch.isLeaseHeld(NOW.plus(Duration.ofMinutes(31)), LEASE)).isFalse();
+    }
+
+    @Test
+    @DisplayName("FAILED는 진행 중이 아니므로 리스와 무관하게 다음 시도가 집어간다")
+    void isLeaseHeld_failedIsNotHeld() {
+        ReportDispatch dispatch = ReportDispatch.claim(JULY, NOW);
+        dispatch.markFailed("MAIL_SEND_FAILED", NOW);
+
+        assertThat(dispatch.isLeaseHeld(NOW, LEASE)).isFalse();
+    }
+}

--- a/src/test/java/com/company/officecommute/repository/report/ReportDispatchRepositoryMySqlIntegrationTest.java
+++ b/src/test/java/com/company/officecommute/repository/report/ReportDispatchRepositoryMySqlIntegrationTest.java
@@ -1,0 +1,53 @@
+package com.company.officecommute.repository.report;
+
+import com.company.officecommute.domain.report.ReportDispatch;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.testcontainers.containers.MySQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+import java.time.Instant;
+import java.time.YearMonth;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * H2({@code ReportDispatchRepositoryTest})는 엔티티 매핑으로 스키마를 만들기 때문에
+ * "V13 마이그레이션이 엔티티와 어긋났다"를 잡지 못한다. 여기서는 Flyway 로 실제 마이그레이션을
+ * 적용하고 {@code ddl-auto=validate} 로 검증하므로, 컨텍스트가 뜨는 것 자체가 V13 정합 검사다.
+ * <p>
+ * Docker 가 없는 환경에서는 건너뛴다(기존 MySQL 통합 테스트와 같은 조건).
+ */
+@SpringBootTest(properties = {
+        "spring.flyway.enabled=true",
+        "spring.jpa.hibernate.ddl-auto=validate",
+        "spring.jpa.defer-datasource-initialization=false",
+        "spring.sql.init.mode=never"
+})
+@Testcontainers(disabledWithoutDocker = true)
+class ReportDispatchRepositoryMySqlIntegrationTest {
+
+    private static final YearMonth JULY = YearMonth.of(2026, 7);
+    private static final Instant NOW = Instant.parse("2026-08-01T06:00:00Z");
+
+    @Container
+    @ServiceConnection
+    static final MySQLContainer<?> MYSQL = new MySQLContainer<>("mysql:8.4");
+
+    @Autowired
+    private ReportDispatchRepository reportDispatchRepository;
+
+    @Test
+    @DisplayName("V13 의 uk_report_dispatch_year_month 가 같은 달의 두 번째 선점을 막는다")
+    void duplicateYearMonth_rejectedByMigrationConstraint() {
+        reportDispatchRepository.saveAndFlush(ReportDispatch.claim(JULY, NOW));
+
+        assertThatThrownBy(() -> reportDispatchRepository.saveAndFlush(ReportDispatch.claim(JULY, NOW)))
+                .isInstanceOf(DataIntegrityViolationException.class);
+    }
+}

--- a/src/test/java/com/company/officecommute/repository/report/ReportDispatchRepositoryTest.java
+++ b/src/test/java/com/company/officecommute/repository/report/ReportDispatchRepositoryTest.java
@@ -1,0 +1,55 @@
+package com.company.officecommute.repository.report;
+
+import com.company.officecommute.domain.report.ReportDispatch;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.dao.DataIntegrityViolationException;
+
+import java.time.Instant;
+import java.time.YearMonth;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@DataJpaTest
+class ReportDispatchRepositoryTest {
+
+    private static final YearMonth JULY = YearMonth.of(2026, 7);
+    private static final Instant NOW = Instant.parse("2026-08-01T06:00:00Z");
+
+    @Autowired
+    private ReportDispatchRepository reportDispatchRepository;
+
+    @Test
+    @DisplayName("같은 대상 월로 두 번 선점하면 두 번째가 제약 위반으로 실패한다 — 중복 발송 방지의 하드 보증")
+    void duplicateYearMonth_violatesUniqueConstraint() {
+        reportDispatchRepository.saveAndFlush(ReportDispatch.claim(JULY, NOW));
+
+        assertThatThrownBy(() -> reportDispatchRepository.saveAndFlush(ReportDispatch.claim(JULY, NOW)))
+                .isInstanceOf(DataIntegrityViolationException.class);
+    }
+
+    @Test
+    @DisplayName("다른 대상 월은 나란히 존재한다")
+    void differentYearMonth_coexists() {
+        reportDispatchRepository.saveAndFlush(ReportDispatch.claim(JULY, NOW));
+        reportDispatchRepository.saveAndFlush(ReportDispatch.claim(JULY.minusMonths(1), NOW));
+
+        assertThat(reportDispatchRepository.findAll()).hasSize(2);
+    }
+
+    @Test
+    @DisplayName("YearMonth는 'yyyy-MM' 문자열로 저장돼 그대로 되읽힌다")
+    void yearMonthRoundTrips() {
+        reportDispatchRepository.saveAndFlush(ReportDispatch.claim(JULY, NOW));
+        reportDispatchRepository.flush();
+
+        assertThat(reportDispatchRepository.findByTargetYearMonth(JULY))
+                .isPresent()
+                .get()
+                .extracting(ReportDispatch::getTargetYearMonth)
+                .isEqualTo(JULY);
+    }
+}


### PR DESCRIPTION
ADR 3 분할 PR **3/7**. base: `claude/adr3-02-mail` (#42)

**아직 호출자가 없다** — 발송 유스케이스는 4/7에서 붙는다.

## 변경

- `V13__report_dispatch.sql` + `ReportDispatch` 엔티티 (**같은 커밋이어야 한다**: dev 프로파일은 Flyway가 꺼진 `ddl-auto: create-drop`이라 나누면 dev 부팅과 prod 스키마가 어긋난다 — V10 때와 같은 이유)
- `YearMonthAttributeConverter`, `DispatchStatus`, `ReportDispatchRepository`

## 설계 근거

- **`UNIQUE(target_year_month)`가 "대표는 한 달에 한 통"의 유일한 하드 보증**이다. 스케줄 간격·상태 전이는 전부 그 위의 편의 계층이라, 배치 재시도와 수동 재실행이 겹쳐도 두 통이 나갈 수 없다
- `CHAR(7)` 'yyyy-MM' — `DATE`로 두면 "1일"이라는 존재하지 않는 날짜가 의미를 갖는 것처럼 보인다
- 상태 전이(`claim`/`beginAttempt`/`markSent`/`markFailed`)를 엔티티가 소유해 바깥에서 status만 바꿔치는 경로를 없앴다
- `isLeaseHeld`: 발송 도중 죽은 `IN_PROGRESS`가 그 달을 영원히 잠그지 않도록 리스 만료분은 회수 대상으로 본다
- 실패 사유는 컬럼 길이(1000)로 잘라 저장 — 기록하려다 저장이 터지면 본말전도

## 리뷰 포인트

마이그레이션 번호가 **V13**인지 확인 부탁드립니다. ADR 3 본문은 V12로 적혀 있었는데, 리베이스로 V11은 admin 비밀번호 로테이션, V12는 퇴사일이 차지했습니다. (ADR 본문 보정은 7/7에 있습니다.)

## 검증

`./gradlew check` green.

- `ReportDispatchTest` 7건 (상태 전이·리스), `ReportDispatchRepositoryTest` 3건 (유니크 제약·`yyyy-MM` 라운드트립) — H2에서 실행됨
- ⚠️ `ReportDispatchRepositoryMySqlIntegrationTest`는 **Docker 부재로 skip**됐습니다. V13 SQL과 엔티티 매핑의 정합(Flyway + `ddl-auto=validate`)을 검증하는 테스트라, Docker 있는 환경에서 한 번 돌려봐야 합니다

---
_Generated by [Claude Code](https://claude.ai/code/session_01RNw4fkDjtJBRJXWx9dc5p1)_