### PR TITLE
docs(ops): 메일 발송 운영 설정 문서화 + ADR 3·TODO 갱신 (ADR 3 Step 7)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -19,6 +19,27 @@ PUBLIC_API_READ_TIMEOUT=5s
 # 서버 포트 (선택사항)
 SERVER_PORT=8080
 
+# ----------------------------------------------------------------------
+# 매월 초과근무 리포트 메일 발송 (ADR 3)
+#   prod 프로파일은 아래 값에 기본값이 없다 — 미설정 시 부팅이 실패한다.
+#   매월 1일에야 "메일이 안 온다"를 발견하는 것보다 부팅 실패가 싸다.
+#   dev/mysql 은 spring.mail.host 기본값(localhost)으로 뜨며 실제 발송 경로가 없다.
+# ----------------------------------------------------------------------
+MAIL_HOST=
+MAIL_PORT=587
+MAIL_USERNAME=
+MAIL_PASSWORD=
+# SMTP 인증/STARTTLS 사용 여부 (선택, prod 기본값 true)
+MAIL_SMTP_AUTH=true
+MAIL_SMTP_STARTTLS=true
+
+# 발신 주소
+REPORT_MAIL_FROM=
+# 대표 — 정상 리포트의 유일한 수신자
+REPORT_MAIL_CEO=
+# 근태 관리자 — 미마감 보류·발송 실패 알림 수신자. 복수는 쉼표 구분(a@x.com,b@x.com)
+REPORT_MAIL_MANAGERS=
+
 # 시드 admin 비밀번호 로테이션용 BCrypt 해시 (V11, 운영 필수 — 미설정 시 prod 부팅 실패)
 # dev/mysql 프로파일에서는 없어도 된다 (dev 는 Flyway 미사용, mysql 은 dev 해시 기본값)
 ADMIN_PASSWORD_HASH=

--- a/TODO.md
+++ b/TODO.md
@@ -113,29 +113,37 @@
 잘못된 급여 자료가 대표에게 도착하는 것이 메일이 하루 늦는 것보다 비싸다.
 문제가 있으면 대표 메일 대신 근태 관리자에게 경고를 보낸다.
 
-**전제: 배치도 메일 발송도 아직 없다.** 스케줄러(`@Scheduled`)와 메일 의존성이
-프로젝트에 존재하지 않으므로, 이 절의 항목들은 기존 코드의 수정이 아니라
-발송 경로를 새로 만드는 작업이다. 리포트 생성부(`OverTimeReportService`)는 준비돼 있다.
+**구현 완료 (2026-08-11, ADR 3 Step 1~7).** 스케줄러도 메일도 프로젝트에 없었으므로
+이 절은 기존 코드 수정이 아니라 발송 경로 신설이었다. 설계 근거와 감수 사항은
+`src/test/docs/adr/2026_08_10_adr3.md` 참조.
 
-- [ ] 스케줄러 도입(프로젝트 첫 도입): `@EnableScheduling` + `@Scheduled`에
-      cron `zone = "Asia/Seoul"` 명시. "전월"은 주입된 `Clock`에서 파생 —
-      `LocalDate.now()` 직접 호출 금지
-- [ ] 배치는 `StreamingResponseBody` 컨트롤러를 타지 말고 서비스 계층을 직접 호출한다.
-      실패 시 부분 파일이 나가지 않도록 임시 파일에 다 쓴 뒤 첨부한다
-- [ ] **발송 이력 테이블 `UNIQUE(year_month)`** — 중복 발송 방지의 핵심.
-      배치 재시도와 수동 재실행이 겹쳐도 대표는 한 달에 한 번만 받는다
-- [ ] **재시도가 원장을 대체한다**: 1일 오전 시도가 실패하면(공휴일 API 다운 포함)
-      몇 시간 간격으로 1~3일 재시도. 발송 이력 유니크 덕에 성공 시 자동 중단, 멱등.
-      공휴일 프리플라이트는 별도 항목이 아니다 — 라이브 호출이 fail-closed라
-      데이터 문제가 곧 배치 실패로 드러나고, 재시도 대상이 된다
-- [ ] **조용한 실패 차단** — 재시도까지 소진한 최종 실패는 근태 관리자에게 알림으로
-      드러나야 한다 (메일이 안 온 것과 구분이 안 되면 안 된다)
-- [x] **퇴근 미처리 기록 — 탐지·노출 완료.** `workEndTime IS NULL`이면 `workingMinutes=0`으로 SUM에 들어간다.
-      1일 오전 배치면 전월 말일에 퇴근을 찍지 않은 직원이 그대로 0분 처리된다.
-      `countByWorkDateBetweenAndWorkEndTimeIsNull`로 건수를 세어 `OverTimeReport`에 싣고,
-      시트 첫 행에 경고로 남긴다(연차는 `workEndTime`이 채워지므로 오탐 없음).
-      → 남은 것은 **라우팅**: 건수가 0이 아닐 때 대표 발송을 막고 근태 관리자에게 보낼지 여부.
-      발송 경로가 생긴 뒤 결정한다
+- [x] 스케줄러 도입(프로젝트 첫 도입): `config/SchedulingConfig`(`@EnableScheduling`)와
+      `scheduler/OverTimeReportDispatchScheduler`(`@Profile("prod")`).
+      cron `zone = "Asia/Seoul"` 명시, "전월"은 주입된 `Clock`에서 파생.
+      `Clock` 빈이 `systemDefaultZone()`이라 cron zone 과 날짜 파생 zone 을 **둘 다** KST 로
+      못박아야 서버 TZ 가 UTC 일 때 대상 월이 한 달 밀리지 않는다(테스트가 고정)
+- [x] 배치는 컨트롤러를 타지 않고 서비스를 직접 호출한다.
+      **임시 파일 대신 메모리 버퍼**(`ByteArrayOutputStream`)로 바꿨다 — 지시의 의도인
+      "부분 파일 차단"은 동일하게 충족되고, 수백 KB 규모에 임시 파일은 잔여물·권한·정리
+      책임만 늘린다. 재검토 조건은 ADR 3 Step 3에 남겼다(첨부가 수 MB급이 되면 파일로 회귀)
+- [x] **발송 이력 테이블 `UNIQUE(target_year_month)`** — `V13__report_dispatch.sql`.
+      중복 발송 방지의 유일한 하드 보증이고 나머지는 그 위의 편의 계층이다
+- [x] **재시도가 원장을 대체한다**: 1~3일 × 하루 4회(06/10/14/18 KST) = 최대 12회.
+      이력 유니크와 `SENT` 종착 상태 덕에 성공 시 자동 중단, 멱등.
+      공휴일 프리플라이트는 두지 않았다 — 라이브 호출이 fail-closed 라 데이터 문제가
+      곧 `FAILED(HOLIDAY_DATA_UNAVAILABLE)`로 드러나고 재시도 대상이 된다
+- [x] **조용한 실패 차단** — 3일 20:00(마지막 시도 2시간 뒤) 별도 스케줄이 미발송을 점검해
+      근태 관리자에게 알린다. 이력이 아예 없으면 "스케줄러 미동작"으로 보고 알린다.
+      시도 로직에 "이번이 마지막인가" 조건을 섞지 않으려고 진입점을 분리했다
+- [x] **퇴근 미처리 기록 — 탐지·노출·라우팅 완료.** `workEndTime IS NULL`이면 `workingMinutes=0`으로
+      집계에 들어가 그 직원의 초과근무를 과소 집계한다(= 임금 미지급).
+      → **라우팅을 "막는 쪽"으로 확정**(ADR 3 Step 4): 미마감이 1건이라도 있으면 대표 발송을
+      보류하고, 근태 관리자에게 리포트 + 미마감 목록(`findUnclosedByWorkDateBetween`)을 보내
+      교정을 요청한다. 재시도 창 안에 마감하면 다음 시도에서 자동으로 대표에게 나간다.
+      엑셀 첫 행 경고만으로는 "대표가 경고를 읽었을 것"에 기대게 되므로 경고로 끝내지 않는다
+- [x] 수동 재실행 `POST /api/overtime/report/dispatch` (ManagerOnly) — 배치와 같은 멱등 경로.
+      강제 발송 플래그는 두지 않는다. 응답으로 현재 발송 상태를 돌려주어 관리자가 미마감을
+      고친 뒤 다음 재시도를 기다리지 않고 확인할 수 있다
 
 ## 5. 법정 산정 방식 정합
 
@@ -159,9 +167,15 @@
 
 ## 6. 마이너
 
-- [ ] `OverTimeService.calculateOverTime`에 `@Transactional(readOnly = true)` 부재 —
-      두 쿼리 사이 비일관 스냅샷 가능. 붙일 때는 외부 API 호출(`HolidayApiClient`)을
-      트랜잭션 밖으로 빼야 한다
-- [ ] 외부 API 타임아웃을 `application-*.yml`로 분리 (`RestTemplateConfig`의 기존 TODO)
+- [x] `OverTimeService.calculateOverTime`의 `@Transactional(readOnly = true)` (2026-08-11).
+      두 DB 조회를 `OverTimeSnapshotReader`(`@Transactional(readOnly = true)`)로 묶고
+      공휴일 라이브 호출은 그 밖에 남겼다. 별도 빈으로 뽑은 이유: 같은 클래스 안에서
+      `@Transactional` 메서드를 자기호출하면 프록시를 타지 않아 애초에 트랜잭션이 걸리지 않는다 —
+      트랜잭션 경계를 클래스 경계와 일치시켰다
+- [x] 외부 API 타임아웃을 `application-*.yml`로 분리 (2026-08-11).
+      `public.data.api.connectTimeout`/`readTimeout`(기본 3s/5s)으로 노출해
+      `PUBLIC_API_CONNECT_TIMEOUT`/`PUBLIC_API_READ_TIMEOUT`으로 재배포 없이 조정한다.
+      배치가 공휴일 API 에 매달리면 재시도 창을 통째로 잡아먹는다 — 온디맨드 조회와 달리
+      사람이 보고 있지 않다
 - [x] `HolidayResponse.Item.setLocDate` 오타 수정 (`setLocdate`, 필드와 일치 — 클라이언트
       분리에 딸려 처리)

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -128,6 +128,16 @@ server:
 | `PUBLIC_API_SERVICE_KEY` | 공공데이터포털 키 | 미설정 시 부팅 실패 — 배포 전 발급 확인 |
 | `ADMIN_PASSWORD_HASH` | BCrypt 해시 | **신규** (§1-4) |
 | `SERVER_PORT` | 8080 (컨테이너 내부) | |
+| `MAIL_HOST` / `MAIL_PORT` / `MAIL_USERNAME` / `MAIL_PASSWORD` | 사내 SMTP 또는 Gmail 앱 비밀번호 | **신규** (ADR 3). prod 기본값 없음 — 미설정 시 부팅 실패 |
+| `MAIL_SMTP_AUTH` / `MAIL_SMTP_STARTTLS` | `true` | **신규**. 선택 — 미설정 시 둘 다 true |
+| `REPORT_MAIL_FROM` | 발신 주소 | **신규**. prod 기본값 없음 |
+| `REPORT_MAIL_CEO` | 대표 메일 | **신규**. 정상 리포트의 유일한 수신자 |
+| `REPORT_MAIL_MANAGERS` | 근태 관리자 메일 | **신규**. 쉼표 구분 복수 가능. 미마감 보류·발송 실패 알림 수신자 |
+| `PUBLIC_API_CONNECT_TIMEOUT` / `PUBLIC_API_READ_TIMEOUT` | `3s` / `5s` | **신규**. 선택 — 배치가 공휴일 API 에 매달려 재시도 창을 잡아먹지 않도록 재배포 없이 조정 |
+
+> 메일 설정에 기본값을 두지 않는 이유: 배치는 매월 1일에만 돈다. 값이 비어 있어도 앱이
+> 뜨면 한 달 뒤 "리포트가 안 왔다"로 발견되고, 그 시점엔 이미 급여 정산이 지나 있다.
+> `ADMIN_PASSWORD_HASH`와 같은 방침으로 부팅 시점에 실패시킨다.
 
 시크릿은 서버의 `.env`(gitignored) 또는 GitHub Actions Secrets로만 관리한다. docker-compose.yml의 로컬용 고정 비밀번호(`office_password` 등)를 운영에 재사용하지 않는다.
 
@@ -142,6 +152,10 @@ server:
 7. SPA 라우트(`/teams`, `/employees`, `/overtime`) 직접 접속/새로고침 정상 확인.
 8. `scripts/api_test.sh`를 운영 오리진으로 스모크 실행 (admin 자격증명은 새 값으로).
 9. DB 백업 크론 + 로그 로테이션(`logs/office-commute.log`, 설정상 100MB/30일) 동작 확인.
+10. 메일 설정 주입 확인 → `POST /api/overtime/report/dispatch?yearMonth=<지난달>`을 MANAGER 로 한 번 호출해
+    응답의 `status`가 `SENT`(또는 미마감이 있으면 `FAILED` + `UNCLOSED_COMMUTES`)로 나오는지 확인.
+    배치 첫 발화(다음 달 1일 06:00 KST)를 기다리지 않고 발송 경로 전체를 검증하는 방법이다.
+    이미 발송된 달이면 아무 일도 일어나지 않으므로(멱등) 스모크로 안전하다.
 
 ## 6. 배포 후 개선 로드맵 (권고 — 차단 아님)
 

--- a/src/test/docs/adr/2026_08_10_adr3.md
+++ b/src/test/docs/adr/2026_08_10_adr3.md
@@ -1,7 +1,7 @@
 # ADR 3. 매월 1일 초과근무 리포트 자동 발송 — 배치 + 메일 경로 신설
 
 - 날짜: 2026-08-10
-- 상태: 제안 (구현 전) — 관련: TODO.md 4번(본체), 3번 잔여(퇴사자), 6번 일부(타임아웃)
+- 상태: 구현 완료 (2026-08-11, Step 1~7) — 관련: TODO.md 4번(본체), 3번 잔여(퇴사자), 6번 일부(타임아웃)
 - 선행: ADR 1(주 단위 산정)로 리포트 수치 자체는 정합해졌다. 이제 그 수치를 **내보내는** 경로를 만든다.
 
 ## 배경
@@ -26,7 +26,7 @@
 | 미마감 게이트 | `unclosedCommuteCount > 0`이면 **대표 발송 보류**, 근태 관리자에게 교정 요청 | 미마감은 그 직원의 초과근무를 과소 집계한다 = 조용히 틀린 급여 근거 |
 | 최종 실패 | 3일 20:00에 미발송 대상 점검 → 근태 관리자에게 알림 | "메일이 안 온 것"과 "실패한 것"이 구분돼야 한다 |
 | 첨부 방식 | 메모리 버퍼(`ByteArrayResource`)에 **다 쓴 뒤** 첨부 | TODO의 "임시 파일" 지시에서 변경 — 아래 Step 3 참조 |
-| 수동 재실행 | `POST /overtime/report/dispatch` (`@ManagerOnly`), 배치와 **같은 멱등 메서드** | 강제 플래그를 두지 않는다. 이미 SENT면 아무 일도 일어나지 않는다 |
+| 수동 재실행 | `POST /api/overtime/report/dispatch` (`@ManagerOnly`), 배치와 **같은 멱등 메서드** | 강제 플래그를 두지 않는다. 이미 SENT면 아무 일도 일어나지 않는다 |
 
 ---
 
@@ -65,13 +65,13 @@ GreenMail 등 새 테스트 의존성은 도입하지 않는다.
 
 ## Step 2. 발송 이력 — 멱등성의 근거
 
-**마이그레이션 `V12__report_dispatch.sql`** (원문 V11 — Step 0.3 선행 조치인 퇴사자 처리가
-`V11__employee_work_end_date.sql`을 사용해 한 칸 밀림, 2026-08-10)
+**마이그레이션 `V13__report_dispatch.sql`** (원문 V11 — 리베이스로 V11은 admin 비밀번호
+로테이션, V12는 Step 0.3 선행 조치인 `V12__employee_work_end_date.sql`이 차지해 두 칸 밀림, 2026-08-11)
 
 ```sql
 CREATE TABLE report_dispatch (
     report_dispatch_id BIGINT NOT NULL AUTO_INCREMENT,
-    target_year_month CHAR(7) NOT NULL,          -- 'yyyy-MM'
+    target_year_month VARCHAR(7) NOT NULL,       -- 'yyyy-MM'
     status VARCHAR(20) NOT NULL,                 -- IN_PROGRESS | SENT | FAILED
     attempt_count INT NOT NULL,
     last_attempted_at DATETIME(6) NOT NULL,
@@ -82,7 +82,9 @@ CREATE TABLE report_dispatch (
 );
 ```
 
-- `CHAR(7)` 'yyyy-MM' — `DATE`로 두면 "1일"이라는 존재하지 않는 날짜가 의미를 갖는 것처럼 보인다.
+- `VARCHAR(7)` 'yyyy-MM' — `DATE`로 두면 "1일"이라는 존재하지 않는 날짜가 의미를 갖는 것처럼 보인다.
+  (원문 `CHAR(7)` — 엔티티의 `@Column(length = 7)`이 `varchar(7)`을 기대해 `ddl-auto=validate`가
+  타입 불일치로 부팅을 막았다. MySQL 통합 테스트로 확인 후 `VARCHAR(7)`로 정정, 2026-08-11)
   JPA는 `YearMonth` ↔ `String` `AttributeConverter` 하나로 처리한다.
 - `UNIQUE(target_year_month)`가 **중복 발송 방지의 유일한 하드 보증**이다. 나머지(스케줄 간격, 상태 전이)는
   전부 그 위의 편의 계층이다.
@@ -200,7 +202,7 @@ public void alertIfNotSent() { ... }  // 전월 이력이 SENT가 아니면 관�
 ## Step 6. 수동 재실행 엔드포인트
 
 ```
-POST /overtime/report/dispatch?yearMonth=2026-07     @ManagerOnly
+POST /api/overtime/report/dispatch?yearMonth=2026-07     @ManagerOnly
 ```
 
 - 배치와 **완전히 같은** `dispatch(YearMonth)`를 호출한다. 강제 발송 플래그는 두지 않는다 —
@@ -248,5 +250,7 @@ POST /overtime/report/dispatch?yearMonth=2026-07     @ManagerOnly
   `Employee.workEndDate` + 재직 겹침 필터. 퇴사자 로그인·출퇴근 차단은 TODO 3에 별도 항목으로 남음
 - 직원별 통상시급(`HOURLY_ORDINARY_WAGE = 15000` 하드코딩) — TODO 5
 - 야간근로(22~06시 +0.5), 휴게시간 미차감 — TODO 5
-- `OverTimeService.calculateOverTime`의 `@Transactional(readOnly = true)` — TODO 6.
-  Step 4에서 "외부 호출을 트랜잭션 밖으로"라는 같은 제약을 이미 다루므로 함께 처리해도 좋다.
+- ~~`OverTimeService.calculateOverTime`의 `@Transactional(readOnly = true)` — TODO 6.~~
+  처리 완료(2026-08-11): 두 DB 조회를 `OverTimeSnapshotReader`(`@Transactional(readOnly = true)`)로
+  묶고 공휴일 라이브 호출은 그 밖에 남겼다. 같은 클래스 안 자기호출은 프록시를 타지 않으므로
+  트랜잭션 경계를 클래스 경계와 일치시켰다.


### PR DESCRIPTION
ADR 3 분할 PR **7/7**. base: `claude/adr3-06-readonly-tx` (#46)

코드 변경 없음. 문서·설정 파일만 4개입니다.

## 변경

- **`.env.example` / `DEPLOYMENT.md` §4**: `MAIL_*` · `REPORT_MAIL_*` 항목 추가. 실값이 아직 없으므로 항목만 두고 비워 뒀습니다
- **배포 체크리스트**에 수동 발송 스모크 추가 — 배치 첫 발화(다음 달 1일 06:00 KST)를 기다리지 않고 발송 경로 전체를 검증할 수 있고, 멱등이라 반복해도 안전합니다
- **ADR 3**: `report_dispatch` 마이그레이션 번호를 **V13**으로 보정(리베이스로 V11은 admin 비밀번호 로테이션, V12는 퇴사일이 차지). 발송 엔드포인트 경로를 `/api` 통일 이후 형태로 맞추고 상태를 구현 완료로 변경
- **TODO**: 4번(본체)을 전부 닫고, 마지막 미결이던 "미마감 시 라우팅"을 이번 결정(대표 발송 보류 + 관리자 교정 요청)으로 닫음. 6번 두 항목도 닫음

## 확인 부탁드릴 결정

**prod 메일 환경변수에 기본값을 두지 않았습니다 — 미설정 시 부팅이 실패합니다.**

배치가 매월 1일에만 도는 이상 "값이 비어도 뜨는" 쪽은 한 달 뒤에야 발견되고, 그때는 이미 급여 정산이 지나 있다고 판단했습니다(`ADMIN_PASSWORD_HASH`와 같은 방침). 다만 **실값이 준비되기 전에 prod를 띄워야 한다면 이 결정을 뒤집어야 합니다.**

## 검증

`./gradlew check` green (코드 변경 없음).

---
_Generated by [Claude Code](https://claude.ai/code/session_01RNw4fkDjtJBRJXWx9dc5p1)_