### PR TITLE
ci: PR/main push 시 backend check + frontend build 실행

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,71 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+# 같은 브랜치에 연속 푸시하면 이전 실행을 취소한다 (러너 시간 절약)
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  # 잡 이름은 브랜치 보호의 required status check 로 등록되므로 함부로 바꾸지 않는다.
+  # (바꾸면 보호 규칙에 등록된 옛 이름이 영원히 pending 으로 남아 머지가 막힌다.)
+  backend:
+    name: backend
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '21'
+
+      # Gradle 배포판 + 의존성 캐싱 (main 에서 캐시 저장, PR 에서 읽기)
+      - uses: gradle/actions/setup-gradle@v4
+
+      # check 에 openApiValidate 가 물려 있어 테스트 + openapi.yml 검증을 함께 돈다.
+      # ubuntu-latest 러너에는 Docker 가 있으므로, 로컬에서 스킵되던
+      # @Testcontainers(disabledWithoutDocker = true) 테스트도 여기서는 실제로 실행된다.
+      - run: ./gradlew check
+
+      - name: Upload test report
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: backend-test-report
+          path: build/reports/tests/test
+          retention-days: 7
+
+  frontend:
+    name: frontend
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    defaults:
+      run:
+        working-directory: frontend
+    steps:
+      - uses: actions/checkout@v4
+
+      # pnpm-workspace.yaml 의 allowBuilds 는 pnpm 10 문법이다.
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 10
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: pnpm
+          # 프론트가 서브디렉토리에 있어 lockfile 경로를 명시해야 캐시가 붙는다.
+          cache-dependency-path: frontend/pnpm-lock.yaml
+
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm lint
+      - run: pnpm build # tsc --noEmit && vite build

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -107,10 +107,8 @@ server:
 
 ## 3. 빌드·배포 파이프라인 (GitHub Actions 권장)
 
-현재 CI가 없다(`.github/`에 이슈 템플릿뿐). 최소 파이프라인:
-
-1. **CI (PR/main push)**: `./gradlew check` (테스트 + openApiValidate) + `cd frontend && pnpm install --frozen-lockfile && pnpm build` (tsc 포함). Testcontainers 사용하므로 러너에 Docker 필요 (Testcontainers 1.21.4 핀 유지).
-2. **CD (main 태그/수동 트리거)**:
+1. **CI (PR/main push)** — `.github/workflows/ci.yml` 로 구현됨. `backend` 잡이 `./gradlew check`(테스트 + openApiValidate), `frontend` 잡이 `pnpm install --frozen-lockfile && pnpm lint && pnpm build`(tsc 포함)를 돈다. Testcontainers 사용하므로 러너에 Docker 필요 — `ubuntu-latest`는 기본 제공 (Testcontainers 1.21.4 핀 유지). 잡 이름 `backend`/`frontend`를 `main` 브랜치 보호의 required status check 로 등록해야 실제로 머지를 막는다.
+2. **CD (main 태그/수동 트리거)** — 미구현:
    - 백엔드: `./gradlew bootJar` → Dockerfile(eclipse-temurin:21-jre)로 이미지 빌드 → 레지스트리 push → 서버에서 `docker compose pull && up -d app`.
    - 프론트: `pnpm build` → `dist/`를 서버 정적 경로로 rsync → `nginx -s reload`.
 3. **롤백**: 이미지 태그를 커밋 SHA로 지정해 이전 태그로 `up -d`. 프론트는 이전 dist 디렉토리 심볼릭 링크 전환.


### PR DESCRIPTION
## 왜

`.github/` 에 이슈 템플릿만 있고 CI가 없어서, 테스트 실패나 타입 오류가 머지된 뒤에야 드러나는 상태였다. `docs/DEPLOYMENT.md` §3 이 이미 설계해 둔 최소 파이프라인 중 1단계(CI)를 워크플로로 옮긴다. CD는 시크릿 관리가 선행되어야 해서 이번 범위 밖.

## 무엇

`.github/workflows/ci.yml` — `pull_request` 와 `main` push 에서 두 잡을 병렬 실행.

| 잡 | 하는 일 |
|---|---|
| `backend` | Temurin 21 + `gradle/actions/setup-gradle` 캐시 → `./gradlew check`. 실패 시 `build/reports/tests/test` 를 아티팩트로 업로드 |
| `frontend` | pnpm 10 + Node 22 → `pnpm install --frozen-lockfile` → `pnpm lint` → `pnpm build` |

이 레포에 맞춘 부분:

- **`./gradlew check` 한 줄**로 충분하다 — `build.gradle` 이 `check` 에 `openApiValidate` 를 물려 두어서 테스트와 `openapi.yml` 문법 검증이 함께 돈다. `test` 로 바꾸면 스펙 검증이 빠진다.
- 프론트가 서브디렉토리라 `defaults.run.working-directory: frontend` 와 `setup-node` 의 `cache-dependency-path: frontend/pnpm-lock.yaml` 이 둘 다 필요하다. 후자를 빼면 루트에서 lockfile 을 못 찾는다.
- pnpm 은 `10` 으로 핀 — `frontend/pnpm-workspace.yaml` 의 `allowBuilds` 가 pnpm 10 문법이다.
- `concurrency` 로 같은 브랜치 연속 푸시 시 이전 실행 취소, `permissions: contents: read` 로 토큰 최소 권한.

`docs/DEPLOYMENT.md` §3 의 "현재 CI가 없다" 문장을 구현된 내용으로 갱신했다.

## 검증

컨테이너에서 실제로 돌려본 결과:

- `./gradlew check` → BUILD SUCCESSFUL (2m 15s)
- `pnpm install --frozen-lockfile` → OK (pnpm 10.33 / lockfileVersion 9.0)
- `pnpm lint` → exit 0, `pnpm build` → exit 0
- 참고로 `pnpm gen:api` 후 `schema.d.ts` diff 없음 — `docs/DEPLOYMENT.md` §5 의 "schema.d.ts 현재 stale" 메모는 이미 해소된 상태다. 드리프트 검사 잡은 이번엔 넣지 않았다.

## 머지 전에 알아둘 것 ⚠️

로컬 검증 환경에는 Docker 가 없어서 `@Testcontainers(disabledWithoutDocker = true)` 가 붙은 MySQL 통합 테스트 2건(`ReportDispatchRepositoryMySqlIntegrationTest`, `AnnualLeaveServiceMySqlIntegrationTest`)이 **조용히 스킵된 상태**로 통과했다. `ubuntu-latest` 러너에는 Docker 가 있으므로 CI 에서는 이 둘이 실제로 실행된다. 즉 이 PR 의 첫 CI 실행이 지금까지 아무도 돌려본 적 없는 테스트를 처음 돌리는 셈이라, 이 2건만 붉어질 가능성이 있다. 그건 워크플로 설정 문제가 아니라 CI 가 새로 드러낸 것이므로, 실패하면 업로드된 test report 로 잡으면 된다.

## 머지 후 할 일

CI 는 돌기만 해서는 머지를 막지 못한다. 첫 실행이 초록인 걸 확인한 뒤 Settings → Branches(또는 Rulesets)에서 `main` 에:

- Require a pull request before merging
- Require status checks to pass → **`backend`**, **`frontend`** 추가
- Require branches to be up to date before merging

잡 이름은 여기 등록되는 값이라, 나중에 `name:` 을 바꾸면 보호 규칙의 옛 이름이 영원히 pending 으로 남아 머지가 막힌다. 워크플로에도 주석으로 남겨 두었다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016P8ribaz2TEUUKrVG6B55T

---
_Generated by [Claude Code](https://claude.ai/code/session_016P8ribaz2TEUUKrVG6B55T)_