### PR TITLE
fix(deploy): prod compose에 메일·타임아웃 환경변수 전달 추가

### DIFF
--- a/deploy/docker-compose.prod.yml
+++ b/deploy/docker-compose.prod.yml
@@ -3,7 +3,9 @@
 # 사용법 (서버에서):
 #   1. frontend 빌드 산출물(dist/)을 이 파일 옆의 ./dist 로 배치 (rsync)
 #   2. 시크릿은 이 파일 옆의 .env (gitignored) 로만 주입:
-#      APP_IMAGE, DB_URL, DB_USERNAME, DB_PASSWORD, PUBLIC_API_SERVICE_KEY, ADMIN_PASSWORD_HASH
+#      APP_IMAGE, DB_URL, DB_USERNAME, DB_PASSWORD, PUBLIC_API_SERVICE_KEY, ADMIN_PASSWORD_HASH,
+#      MAIL_HOST, MAIL_PORT, MAIL_USERNAME, MAIL_PASSWORD,
+#      REPORT_MAIL_FROM, REPORT_MAIL_CEO, REPORT_MAIL_MANAGERS
 #      — 로컬용 고정 비밀번호(office_password 등)를 운영에 재사용하지 않는다 (§4)
 #   3. docker compose -f docker-compose.prod.yml up -d
 #
@@ -37,6 +39,18 @@ services:
       DB_PASSWORD: ${DB_PASSWORD}
       PUBLIC_API_SERVICE_KEY: ${PUBLIC_API_SERVICE_KEY}
       ADMIN_PASSWORD_HASH: ${ADMIN_PASSWORD_HASH}
+      # 메일 발송 (ADR 3) — prod 는 기본값이 없어 누락 시 부팅 실패가 정상 (§4 fail-fast)
+      MAIL_HOST: ${MAIL_HOST}
+      MAIL_PORT: ${MAIL_PORT}
+      MAIL_USERNAME: ${MAIL_USERNAME}
+      MAIL_PASSWORD: ${MAIL_PASSWORD}
+      MAIL_SMTP_AUTH: ${MAIL_SMTP_AUTH:-true}
+      MAIL_SMTP_STARTTLS: ${MAIL_SMTP_STARTTLS:-true}
+      REPORT_MAIL_FROM: ${REPORT_MAIL_FROM}
+      REPORT_MAIL_CEO: ${REPORT_MAIL_CEO}
+      REPORT_MAIL_MANAGERS: ${REPORT_MAIL_MANAGERS}
+      PUBLIC_API_CONNECT_TIMEOUT: ${PUBLIC_API_CONNECT_TIMEOUT:-3s}
+      PUBLIC_API_READ_TIMEOUT: ${PUBLIC_API_READ_TIMEOUT:-5s}
     volumes:
       - app-logs:/app/logs
 


### PR DESCRIPTION
## 문제

`deploy/docker-compose.prod.yml`의 `app.environment:`에 ADR 3(배치 메일 발송)에서 추가된 환경변수들이 없습니다. compose는 `environment:`에 나열된 변수만 컨테이너에 전달하므로, **서버 `.env`에 메일 설정을 전부 채워도 앱 컨테이너에는 도달하지 않습니다.** prod 프로파일은 메일 설정에 기본값을 두지 않는 fail-fast 정책이라(`application-prod.yml`), 이 상태로는 운영 부팅이 항상 실패합니다.

PR #47(ADR 3 Step 7)이 `.env.example`과 `docs/DEPLOYMENT.md` §4에는 변수를 추가했지만 전달 통로인 compose 파일이 빠져 있었습니다.

## 수정

- 필수 변수 전달 추가: `MAIL_HOST`, `MAIL_PORT`, `MAIL_USERNAME`, `MAIL_PASSWORD`, `REPORT_MAIL_FROM`, `REPORT_MAIL_CEO`, `REPORT_MAIL_MANAGERS`
- 선택 변수는 compose 기본값을 `application-prod.yml`의 기본값과 일치시켜 전달: `MAIL_SMTP_AUTH`/`MAIL_SMTP_STARTTLS`(true), `PUBLIC_API_CONNECT_TIMEOUT`(3s)/`PUBLIC_API_READ_TIMEOUT`(5s)
- 헤더 주석의 `.env` 주입 목록 동기화

## 검증

`docker compose -f docker-compose.prod.yml config`로 렌더링 확인 — 필수 변수가 컨테이너 환경으로 전달되고, 선택 변수 미설정 시 기본값(true, 3s/5s)이 적용됩니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)